### PR TITLE
Add test coverage for theme modules

### DIFF
--- a/modules/ButtonConfig/ButtonConfigModule.php
+++ b/modules/ButtonConfig/ButtonConfigModule.php
@@ -12,7 +12,7 @@ use Sitchco\Framework\Module;
  * By default, both outline and fill variations are REMOVED.
  * Enable specific variations in theme config to preserve them.
  *
- * @package Sitchco\Parent
+ * @package Sitchco\Parent\Modules\ButtonConfig
  */
 class ButtonConfigModule extends Module
 {
@@ -33,7 +33,7 @@ class ButtonConfigModule extends Module
     /**
      * Feature method: Preserve the outline button variation.
      *
-     * Enable in config: ButtonConfig::class => ['outline' => true]
+     * Enable in config: ButtonConfigModule::class => ['outline' => true]
      */
     public function outline(): void
     {
@@ -43,7 +43,7 @@ class ButtonConfigModule extends Module
     /**
      * Feature method: Preserve the fill button variation.
      *
-     * Enable in config: ButtonConfig::class => ['fill' => true]
+     * Enable in config: ButtonConfigModule::class => ['fill' => true]
      */
     public function fill(): void
     {

--- a/modules/ButtonConfig/ButtonConfigModule.php
+++ b/modules/ButtonConfig/ButtonConfigModule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sitchco\Parent;
+namespace Sitchco\Parent\Modules\ButtonConfig;
 
 use Sitchco\Framework\Module;
 
@@ -14,7 +14,7 @@ use Sitchco\Framework\Module;
  *
  * @package Sitchco\Parent
  */
-class ButtonConfig extends Module
+class ButtonConfigModule extends Module
 {
     public const HOOK_SUFFIX = 'button-config';
 

--- a/modules/ContentPartial/ContentPartialService.php
+++ b/modules/ContentPartial/ContentPartialService.php
@@ -34,6 +34,11 @@ class ContentPartialService
         $this->repository = $repository;
     }
 
+    public function getTemplateAreas(): array
+    {
+        return $this->templateAreas;
+    }
+
     public function addTemplateArea(string $templateAreaName, bool $hasContext = true): void
     {
         $this->templateAreas[$templateAreaName] = $hasContext;

--- a/modules/ContentSlider/ContentSlider.php
+++ b/modules/ContentSlider/ContentSlider.php
@@ -61,7 +61,7 @@ class ContentSlider extends Module
         );
     }
 
-    public function scanVariations(): array
+    private function scanVariations(): array
     {
         return Cache::remember('content_slider_variations', function () {
             $variations = [];

--- a/modules/ContentSlider/ContentSlider.php
+++ b/modules/ContentSlider/ContentSlider.php
@@ -61,7 +61,7 @@ class ContentSlider extends Module
         );
     }
 
-    private function scanVariations(): array
+    public function scanVariations(): array
     {
         return Cache::remember('content_slider_variations', function () {
             $variations = [];

--- a/modules/Patterns/PatternContentSanitizer.php
+++ b/modules/Patterns/PatternContentSanitizer.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Sitchco\Parent\Modules\Patterns;
+
+/**
+ * Pattern Content Sanitizer
+ *
+ * Replaces real text with Lorem Ipsum, images with placeholders,
+ * and videos with placeholders in pattern content.
+ */
+class PatternContentSanitizer
+{
+    private const PLACEHOLDER_IMAGE = 'https://cdn.sitch.co/rtc/placeholder-image.png';
+    private const PLACEHOLDER_VIDEO = 'https://cdn.sitch.co/rtc/placeholder-video.mp4';
+
+    private const LOREM_POOL = [
+        'lorem',
+        'ipsum',
+        'dolor',
+        'sit',
+        'amet',
+        'consectetur',
+        'adipiscing',
+        'elit',
+        'sed',
+        'do',
+        'eiusmod',
+        'tempor',
+        'incididunt',
+        'ut',
+        'labore',
+        'et',
+        'dolore',
+        'magna',
+        'aliqua',
+        'enim',
+        'ad',
+        'minim',
+        'veniam',
+        'quis',
+        'nostrud',
+        'exercitation',
+        'ullamco',
+        'laboris',
+        'nisi',
+        'aliquip',
+        'ex',
+        'ea',
+        'commodo',
+        'consequat',
+        'duis',
+        'aute',
+        'irure',
+        'in',
+        'reprehenderit',
+        'voluptate',
+        'velit',
+        'esse',
+        'cillum',
+        'fugiat',
+        'nulla',
+        'pariatur',
+        'excepteur',
+        'sint',
+        'occaecat',
+        'cupidatat',
+        'non',
+        'proident',
+        'sunt',
+        'culpa',
+        'qui',
+        'officia',
+        'deserunt',
+        'mollit',
+        'anim',
+        'id',
+        'est',
+        'laborum',
+        'cras',
+    ];
+
+    /**
+     * Sanitize pattern content by replacing text with Lorem Ipsum,
+     * images with placeholder, and videos with placeholder.
+     */
+    public function sanitizePatternContent(string $content): string
+    {
+        // Step 1: Replace bgImg URLs in block JSON comments
+        $content = preg_replace('/"bgImg":"[^"]*"/', '"bgImg":"' . self::PLACEHOLDER_IMAGE . '"', $content);
+        $content = preg_replace('/"bgImgID":\d+/', '"bgImgID":0', $content);
+
+        // Step 2: Replace video URLs in block JSON comments
+        $content = preg_replace('/"local":"[^"]*"/', '"local":"' . self::PLACEHOLDER_VIDEO . '"', $content);
+        $content = preg_replace('/"localID":"[^"]*"/', '"localID":""', $content);
+        $content = preg_replace('/"youTube":"[^"]*"/', '"youTube":""', $content);
+        $content = preg_replace('/"vimeo":"[^"]*"/', '"vimeo":""', $content);
+
+        // Step 3: Replace <img src="..."> with placeholder image
+        $content = preg_replace('/(<img\b[^>]*\bsrc=")[^"]*(")/i', '$1' . self::PLACEHOLDER_IMAGE . '$2', $content);
+
+        // Step 4: Clear alt text on images
+        $content = preg_replace('/(<img\b[^>]*\balt=")[^"]*(")/i', '$1$2', $content);
+
+        // Step 5: Replace real href URLs (http/https) with #
+        $content = preg_replace('/(<a\b[^>]*\bhref=")https?:\/\/[^"]*(")/i', '$1#$2', $content);
+
+        // Step 6: Remove id attributes from heading tags
+        $content = preg_replace('/(<h[1-6]\b[^>]*)\s+id="[^"]*"/i', '$1', $content);
+
+        // Step 7: Remove target and rel attributes from <a> tags
+        $content = preg_replace('/(<a\b[^>]*)\s+target="[^"]*"/i', '$1', $content);
+        $content = preg_replace('/(<a\b[^>]*)\s+rel="[^"]*"/i', '$1', $content);
+
+        // Step 8: Replace text content in p, li, h1-h6, figcaption
+        $content = preg_replace_callback(
+            '/(<(?:p|li|h[1-6]|figcaption)\b[^>]*>)(.*?)(<\/(?:p|li|h[1-6]|figcaption)>)/is',
+            function ($matches) {
+                $openTag = $matches[1];
+                $inner = $matches[2];
+                $closeTag = $matches[3];
+
+                $wordCount = $this->countWords($inner);
+                if ($wordCount === 0) {
+                    return $openTag . $inner . $closeTag;
+                }
+
+                return $openTag . $this->generateLoremIpsum($wordCount) . $closeTag;
+            },
+            $content,
+        );
+
+        // Step 9: Replace button text in <a class="wp-block-button__link...">
+        $content = preg_replace_callback(
+            '/(<a\b[^>]*class="[^"]*wp-block-button__link[^"]*"[^>]*>)(.*?)(<\/a>)/is',
+            function ($matches) {
+                $openTag = $matches[1];
+                $inner = $matches[2];
+                $closeTag = $matches[3];
+
+                $wordCount = $this->countWords($inner);
+                if ($wordCount === 0) {
+                    return $openTag . $inner . $closeTag;
+                }
+
+                return $openTag . $this->generateLoremIpsum($wordCount) . $closeTag;
+            },
+            $content,
+        );
+
+        return $content;
+    }
+
+    /**
+     * Generate deterministic Lorem Ipsum text of the given word count.
+     */
+    public function generateLoremIpsum(int $wordCount): string
+    {
+        if ($wordCount <= 0) {
+            return '';
+        }
+
+        $pool = self::LOREM_POOL;
+        $poolSize = count($pool);
+        $words = [];
+
+        for ($i = 0; $i < $wordCount; $i++) {
+            $words[] = $pool[$i % $poolSize];
+        }
+
+        $words[0] = ucfirst($words[0]);
+
+        return implode(' ', $words);
+    }
+
+    /**
+     * Count words in HTML content, decoding entities and stripping inline tags.
+     */
+    public function countWords(string $text): int
+    {
+        // Decode HTML entities first (e.g. &amp; → &)
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        // Strip inline HTML tags (br, strong, em, span, a, etc.)
+        $text = strip_tags($text);
+
+        // Count words
+        $text = trim($text);
+        if ($text === '') {
+            return 0;
+        }
+
+        return str_word_count($text);
+    }
+}

--- a/modules/Patterns/SavePatternsToTheme.php
+++ b/modules/Patterns/SavePatternsToTheme.php
@@ -20,81 +20,12 @@ class SavePatternsToTheme
     private const RESULT_UPDATED = 'updated';
     private const RESULT_UNCHANGED = 'unchanged';
 
-    private const PLACEHOLDER_IMAGE = 'https://cdn.sitch.co/rtc/placeholder-image.png';
-    private const PLACEHOLDER_VIDEO = 'https://cdn.sitch.co/rtc/placeholder-video.mp4';
-
-    private const LOREM_POOL = [
-        'lorem',
-        'ipsum',
-        'dolor',
-        'sit',
-        'amet',
-        'consectetur',
-        'adipiscing',
-        'elit',
-        'sed',
-        'do',
-        'eiusmod',
-        'tempor',
-        'incididunt',
-        'ut',
-        'labore',
-        'et',
-        'dolore',
-        'magna',
-        'aliqua',
-        'enim',
-        'ad',
-        'minim',
-        'veniam',
-        'quis',
-        'nostrud',
-        'exercitation',
-        'ullamco',
-        'laboris',
-        'nisi',
-        'aliquip',
-        'ex',
-        'ea',
-        'commodo',
-        'consequat',
-        'duis',
-        'aute',
-        'irure',
-        'in',
-        'reprehenderit',
-        'voluptate',
-        'velit',
-        'esse',
-        'cillum',
-        'fugiat',
-        'nulla',
-        'pariatur',
-        'excepteur',
-        'sint',
-        'occaecat',
-        'cupidatat',
-        'non',
-        'proident',
-        'sunt',
-        'culpa',
-        'qui',
-        'officia',
-        'deserunt',
-        'mollit',
-        'anim',
-        'id',
-        'est',
-        'laborum',
-        'cras',
-    ];
-
     private string $patternsDir;
 
     /** @var array<string, true> Slugs used within the current batch to prevent collisions. */
     private array $usedSlugs = [];
 
-    public function __construct()
+    public function __construct(private readonly PatternContentSanitizer $sanitizer)
     {
         $this->patternsDir = get_stylesheet_directory() . '/patterns';
     }
@@ -246,17 +177,9 @@ class SavePatternsToTheme
     }
 
     /**
-     * Reset the used slugs tracker. Useful for testing.
-     */
-    public function resetUsedSlugs(): void
-    {
-        $this->usedSlugs = [];
-    }
-
-    /**
      * Generate a slug from the pattern title.
      */
-    public function generateSlug(string $title): string
+    private function generateSlug(string $title): string
     {
         $slug = sanitize_title($title);
         // Remove any leading numbers and dashes that sanitize_title might leave
@@ -278,7 +201,7 @@ class SavePatternsToTheme
     /**
      * Format the pattern content as a PHP file with proper headers.
      */
-    public function formatPatternFile(\WP_Post $post, string $slug): string
+    private function formatPatternFile(\WP_Post $post, string $slug): string
     {
         $themeName = basename(get_stylesheet_directory());
         $title = str_replace('*/', '', $post->post_title);
@@ -303,7 +226,7 @@ class SavePatternsToTheme
         PHP;
 
         $content = str_replace(['<?php', '<?', '?>'], '', $post->post_content);
-        $content = $this->sanitizePatternContent($content);
+        $content = $this->sanitizer->sanitizePatternContent($content);
         return $header . $content . "\n";
     }
 
@@ -336,122 +259,9 @@ class SavePatternsToTheme
     }
 
     /**
-     * Sanitize pattern content by replacing text with Lorem Ipsum,
-     * images with placeholder, and videos with placeholder.
-     */
-    public function sanitizePatternContent(string $content): string
-    {
-        // Step 1: Replace bgImg URLs in block JSON comments
-        $content = preg_replace('/"bgImg":"[^"]*"/', '"bgImg":"' . self::PLACEHOLDER_IMAGE . '"', $content);
-        $content = preg_replace('/"bgImgID":\d+/', '"bgImgID":0', $content);
-
-        // Step 2: Replace video URLs in block JSON comments
-        $content = preg_replace('/"local":"[^"]*"/', '"local":"' . self::PLACEHOLDER_VIDEO . '"', $content);
-        $content = preg_replace('/"localID":"[^"]*"/', '"localID":""', $content);
-        $content = preg_replace('/"youTube":"[^"]*"/', '"youTube":""', $content);
-        $content = preg_replace('/"vimeo":"[^"]*"/', '"vimeo":""', $content);
-
-        // Step 3: Replace <img src="..."> with placeholder image
-        $content = preg_replace('/(<img\b[^>]*\bsrc=")[^"]*(")/i', '$1' . self::PLACEHOLDER_IMAGE . '$2', $content);
-
-        // Step 4: Clear alt text on images
-        $content = preg_replace('/(<img\b[^>]*\balt=")[^"]*(")/i', '$1$2', $content);
-
-        // Step 5: Replace real href URLs (http/https) with #
-        $content = preg_replace('/(<a\b[^>]*\bhref=")https?:\/\/[^"]*(")/i', '$1#$2', $content);
-
-        // Step 6: Remove id attributes from heading tags
-        $content = preg_replace('/(<h[1-6]\b[^>]*)\s+id="[^"]*"/i', '$1', $content);
-
-        // Step 7: Remove target and rel attributes from <a> tags
-        $content = preg_replace('/(<a\b[^>]*)\s+target="[^"]*"/i', '$1', $content);
-        $content = preg_replace('/(<a\b[^>]*)\s+rel="[^"]*"/i', '$1', $content);
-
-        // Step 8: Replace text content in p, li, h1-h6, figcaption
-        $content = preg_replace_callback(
-            '/(<(?:p|li|h[1-6]|figcaption)\b[^>]*>)(.*?)(<\/(?:p|li|h[1-6]|figcaption)>)/is',
-            function ($matches) {
-                $openTag = $matches[1];
-                $inner = $matches[2];
-                $closeTag = $matches[3];
-
-                $wordCount = $this->countWords($inner);
-                if ($wordCount === 0) {
-                    return $openTag . $inner . $closeTag;
-                }
-
-                return $openTag . $this->generateLoremIpsum($wordCount) . $closeTag;
-            },
-            $content,
-        );
-
-        // Step 9: Replace button text in <a class="wp-block-button__link...">
-        $content = preg_replace_callback(
-            '/(<a\b[^>]*class="[^"]*wp-block-button__link[^"]*"[^>]*>)(.*?)(<\/a>)/is',
-            function ($matches) {
-                $openTag = $matches[1];
-                $inner = $matches[2];
-                $closeTag = $matches[3];
-
-                $wordCount = $this->countWords($inner);
-                if ($wordCount === 0) {
-                    return $openTag . $inner . $closeTag;
-                }
-
-                return $openTag . $this->generateLoremIpsum($wordCount) . $closeTag;
-            },
-            $content,
-        );
-
-        return $content;
-    }
-
-    /**
-     * Generate deterministic Lorem Ipsum text of the given word count.
-     */
-    public function generateLoremIpsum(int $wordCount): string
-    {
-        if ($wordCount <= 0) {
-            return '';
-        }
-
-        $pool = self::LOREM_POOL;
-        $poolSize = count($pool);
-        $words = [];
-
-        for ($i = 0; $i < $wordCount; $i++) {
-            $words[] = $pool[$i % $poolSize];
-        }
-
-        $words[0] = ucfirst($words[0]);
-
-        return implode(' ', $words);
-    }
-
-    /**
-     * Count words in HTML content, decoding entities and stripping inline tags.
-     */
-    public function countWords(string $text): int
-    {
-        // Decode HTML entities first (e.g. &amp; → &)
-        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-
-        // Strip inline HTML tags (br, strong, em, span, a, etc.)
-        $text = strip_tags($text);
-
-        // Count words
-        $text = trim($text);
-        if ($text === '') {
-            return 0;
-        }
-
-        return str_word_count($text);
-    }
-
-    /**
      * Find an existing pattern file that was saved from a given post ID.
      */
-    public function findExistingFileForPost(int $postId): ?string
+    private function findExistingFileForPost(int $postId): ?string
     {
         $files = glob($this->patternsDir . '/*.php');
         if (!$files) {

--- a/modules/Patterns/SavePatternsToTheme.php
+++ b/modules/Patterns/SavePatternsToTheme.php
@@ -178,7 +178,7 @@ class SavePatternsToTheme
      *
      * @return string Result constant or error message
      */
-    private function savePatternToTheme(int $postId): string
+    public function savePatternToTheme(int $postId): string
     {
         $post = get_post($postId);
 
@@ -246,9 +246,17 @@ class SavePatternsToTheme
     }
 
     /**
+     * Reset the used slugs tracker. Useful for testing.
+     */
+    public function resetUsedSlugs(): void
+    {
+        $this->usedSlugs = [];
+    }
+
+    /**
      * Generate a slug from the pattern title.
      */
-    private function generateSlug(string $title): string
+    public function generateSlug(string $title): string
     {
         $slug = sanitize_title($title);
         // Remove any leading numbers and dashes that sanitize_title might leave
@@ -270,7 +278,7 @@ class SavePatternsToTheme
     /**
      * Format the pattern content as a PHP file with proper headers.
      */
-    private function formatPatternFile(\WP_Post $post, string $slug): string
+    public function formatPatternFile(\WP_Post $post, string $slug): string
     {
         $themeName = basename(get_stylesheet_directory());
         $title = str_replace('*/', '', $post->post_title);
@@ -331,7 +339,7 @@ class SavePatternsToTheme
      * Sanitize pattern content by replacing text with Lorem Ipsum,
      * images with placeholder, and videos with placeholder.
      */
-    private function sanitizePatternContent(string $content): string
+    public function sanitizePatternContent(string $content): string
     {
         // Step 1: Replace bgImg URLs in block JSON comments
         $content = preg_replace('/"bgImg":"[^"]*"/', '"bgImg":"' . self::PLACEHOLDER_IMAGE . '"', $content);
@@ -401,7 +409,7 @@ class SavePatternsToTheme
     /**
      * Generate deterministic Lorem Ipsum text of the given word count.
      */
-    private function generateLoremIpsum(int $wordCount): string
+    public function generateLoremIpsum(int $wordCount): string
     {
         if ($wordCount <= 0) {
             return '';
@@ -423,7 +431,7 @@ class SavePatternsToTheme
     /**
      * Count words in HTML content, decoding entities and stripping inline tags.
      */
-    private function countWords(string $text): int
+    public function countWords(string $text): int
     {
         // Decode HTML entities first (e.g. &amp; → &)
         $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
@@ -443,7 +451,7 @@ class SavePatternsToTheme
     /**
      * Find an existing pattern file that was saved from a given post ID.
      */
-    private function findExistingFileForPost(int $postId): ?string
+    public function findExistingFileForPost(int $postId): ?string
     {
         $files = glob($this->patternsDir . '/*.php');
         if (!$files) {

--- a/sitchco.config.php
+++ b/sitchco.config.php
@@ -1,7 +1,7 @@
 <?php
 
 use Sitchco\Modules\Wordpress\Cleanup;
-use Sitchco\Parent\ButtonConfig;
+use Sitchco\Parent\Modules\ButtonConfig\ButtonConfigModule;
 use Sitchco\Parent\Modules\ContentPartial\ContentPartialModule;
 use Sitchco\Parent\Modules\ContentPartial\ContentPartialPost;
 use Sitchco\Parent\Modules\ContentPartialBlock\ContentPartialBlockModule;
@@ -19,7 +19,7 @@ return [
         Cleanup::class => [
             'disableGutenbergStyles' => false,
         ],
-        ButtonConfig::class,
+        ButtonConfigModule::class,
         ContentPartialModule::class,
         ContentPartialBlockModule::class,
         SiteHeaderModule::class,

--- a/tests/ButtonConfigModuleTest.php
+++ b/tests/ButtonConfigModuleTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Parent\Modules\ButtonConfig\ButtonConfigModule;
+use Sitchco\Tests\TestCase;
+
+class ButtonConfigModuleTest extends TestCase
+{
+    protected ButtonConfigModule $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = new ButtonConfigModule();
+    }
+
+    public function testInitRegistersFilter(): void
+    {
+        $this->module->init();
+        $this->assertGreaterThan(0, has_filter('block_type_metadata', [$this->module, 'filterButtonStyleVariations']));
+    }
+
+    public function testNonButtonBlockPassedThrough(): void
+    {
+        $metadata = [
+            'name' => 'core/paragraph',
+            'styles' => [['name' => 'outline', 'label' => 'Outline']],
+        ];
+        $result = $this->module->filterButtonStyleVariations($metadata);
+        $this->assertEquals($metadata, $result);
+    }
+
+    public function testRemovesOutlineAndFillByDefault(): void
+    {
+        $result = $this->module->filterButtonStyleVariations($this->buttonMetadata());
+        $styleNames = array_column($result['styles'], 'name');
+        $this->assertNotContains('outline', $styleNames);
+        $this->assertNotContains('fill', $styleNames);
+    }
+
+    public static function styleToggleProvider(): array
+    {
+        return [
+            'outline only' => [['outline'], ['outline'], ['fill']],
+            'fill only' => [['fill'], ['fill'], ['outline']],
+            'both' => [['outline', 'fill'], ['outline', 'fill'], []],
+        ];
+    }
+
+    /**
+     * @dataProvider styleToggleProvider
+     */
+    public function testKeepsEnabledStylesOnly(array $enable, array $expectPresent, array $expectAbsent): void
+    {
+        foreach ($enable as $method) {
+            $this->module->$method();
+        }
+        $result = $this->module->filterButtonStyleVariations($this->buttonMetadata());
+        $styleNames = array_column($result['styles'], 'name');
+        foreach ($expectPresent as $name) {
+            $this->assertContains($name, $styleNames);
+        }
+        foreach ($expectAbsent as $name) {
+            $this->assertNotContains($name, $styleNames);
+        }
+    }
+
+    public function testHandlesEmptyStyles(): void
+    {
+        $metadata = ['name' => 'core/button', 'styles' => []];
+        $result = $this->module->filterButtonStyleVariations($metadata);
+        $this->assertEmpty($result['styles']);
+    }
+
+    public function testHandlesMissingStyles(): void
+    {
+        $metadata = ['name' => 'core/button'];
+        $result = $this->module->filterButtonStyleVariations($metadata);
+        $this->assertArrayNotHasKey('styles', $result);
+    }
+
+    public function testPreservesOtherStyles(): void
+    {
+        $metadata = $this->buttonMetadata();
+        $result = $this->module->filterButtonStyleVariations($metadata);
+        $styleNames = array_column($result['styles'], 'name');
+        $this->assertContains('default', $styleNames);
+        $this->assertContains('squared', $styleNames);
+    }
+
+    public function testStylesArrayIsReindexed(): void
+    {
+        $metadata = $this->buttonMetadata();
+        $result = $this->module->filterButtonStyleVariations($metadata);
+        $keys = array_keys($result['styles']);
+        $this->assertEquals(range(0, count($result['styles']) - 1), $keys);
+    }
+
+    private function buttonMetadata(): array
+    {
+        return [
+            'name' => 'core/button',
+            'styles' => [
+                ['name' => 'default', 'label' => 'Default', 'isDefault' => true],
+                ['name' => 'outline', 'label' => 'Outline'],
+                ['name' => 'fill', 'label' => 'Fill'],
+                ['name' => 'squared', 'label' => 'Squared'],
+            ],
+        ];
+    }
+}

--- a/tests/ButtonConfigModuleTest.php
+++ b/tests/ButtonConfigModuleTest.php
@@ -12,7 +12,7 @@ class ButtonConfigModuleTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->module = new ButtonConfigModule();
+        $this->module = $this->container->make(ButtonConfigModule::class);
     }
 
     public function testInitRegistersFilter(): void

--- a/tests/CloudinaryKadenceModuleTest.php
+++ b/tests/CloudinaryKadenceModuleTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Modules\Cloudinary\CloudinaryUrl;
+use Sitchco\Parent\Modules\CloudinaryKadence\CloudinaryKadenceModule;
+use Sitchco\Tests\TestCase;
+
+class CloudinaryKadenceModuleTest extends TestCase
+{
+    protected CloudinaryKadenceModule $module;
+    protected CloudinaryUrl $cloudinaryUrl;
+    private string $uploadBase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cloudinaryUrl = $this->container->get(CloudinaryUrl::class);
+        $this->module = $this->container->get(CloudinaryKadenceModule::class);
+        $this->uploadBase = wp_get_upload_dir()['baseurl'];
+        if (!$this->cloudinaryUrl->isConfigured()) {
+            $this->markTestSkipped('Cloudinary not configured');
+        }
+    }
+
+    private function uploadUrl(string $path): string
+    {
+        return $this->uploadBase . '/' . $path;
+    }
+
+    private function assertCloudinaryUrl(string $url, string $expectedFilename): void
+    {
+        $this->assertStringStartsWith('https://res.cloudinary.com/', $url);
+        $this->assertStringContainsString($expectedFilename, $url);
+    }
+
+    public function testInitRegistersFilters(): void
+    {
+        $this->module->init();
+        $this->assertNotFalse(
+            has_filter('kadence_blocks_rowlayout_render_block_attributes', [
+                $this->module,
+                'rewriteRowLayoutAttributes',
+            ]),
+        );
+        $this->assertNotFalse(
+            has_filter('kadence_blocks_column_render_block_attributes', [$this->module, 'rewriteColumnAttributes']),
+        );
+    }
+
+    public function testRewriteRowBgImg(): void
+    {
+        $src = $this->uploadUrl('2024/01/hero.jpg');
+        $result = $this->module->rewriteRowLayoutAttributes(['bgImg' => $src]);
+        $this->assertCloudinaryUrl($result['bgImg'], 'hero.jpg');
+    }
+
+    public function testRewriteRowOverlayBgImg(): void
+    {
+        $src = $this->uploadUrl('2024/01/overlay.jpg');
+        $result = $this->module->rewriteRowLayoutAttributes(['overlayBgImg' => $src]);
+        $this->assertCloudinaryUrl($result['overlayBgImg'], 'overlay.jpg');
+    }
+
+    public function testRewriteRowBackgroundSlider(): void
+    {
+        $src1 = $this->uploadUrl('2024/01/slide1.jpg');
+        $src2 = $this->uploadUrl('2024/01/slide2.jpg');
+        $result = $this->module->rewriteRowLayoutAttributes([
+            'backgroundSlider' => [['bgImg' => $src1], ['bgImg' => $src2]],
+        ]);
+        $this->assertCloudinaryUrl($result['backgroundSlider'][0]['bgImg'], 'slide1.jpg');
+        $this->assertCloudinaryUrl($result['backgroundSlider'][1]['bgImg'], 'slide2.jpg');
+    }
+
+    public static function responsiveBackgroundKeysProvider(): array
+    {
+        return [
+            'tabletBackground' => ['tabletBackground'],
+            'mobileBackground' => ['mobileBackground'],
+        ];
+    }
+
+    /**
+     * @dataProvider responsiveBackgroundKeysProvider
+     */
+    public function testRewriteRowResponsiveBackgrounds(string $key): void
+    {
+        $src = $this->uploadUrl('2024/01/responsive-bg.jpg');
+        $result = $this->module->rewriteRowLayoutAttributes([
+            $key => [['bgImg' => $src]],
+        ]);
+        $this->assertCloudinaryUrl($result[$key][0]['bgImg'], 'responsive-bg.jpg');
+    }
+
+    public static function responsiveOverlayKeysProvider(): array
+    {
+        return [
+            'tabletOverlay' => ['tabletOverlay'],
+            'mobileOverlay' => ['mobileOverlay'],
+        ];
+    }
+
+    /**
+     * @dataProvider responsiveOverlayKeysProvider
+     */
+    public function testRewriteRowResponsiveOverlays(string $key): void
+    {
+        $src = $this->uploadUrl('2024/01/overlay.jpg');
+        $result = $this->module->rewriteRowLayoutAttributes([
+            $key => [['overlayBgImg' => $src]],
+        ]);
+        $this->assertCloudinaryUrl($result[$key][0]['overlayBgImg'], 'overlay.jpg');
+    }
+
+    public static function videoKeysProvider(): array
+    {
+        return [
+            'backgroundVideo' => ['backgroundVideo'],
+            'tabletBackgroundVideo' => ['tabletBackgroundVideo'],
+            'mobileBackgroundVideo' => ['mobileBackgroundVideo'],
+        ];
+    }
+
+    /**
+     * @dataProvider videoKeysProvider
+     */
+    public function testRewriteRowVideoAttributes(string $key): void
+    {
+        $src = $this->uploadUrl('2024/01/video.mp4');
+        $result = $this->module->rewriteRowLayoutAttributes([
+            $key => [['local' => $src]],
+        ]);
+        $this->assertCloudinaryUrl($result[$key][0]['local'], 'video.mp4');
+    }
+
+    public static function columnAttributeKeysProvider(): array
+    {
+        return [
+            'backgroundImg' => ['backgroundImg'],
+            'backgroundImgHover' => ['backgroundImgHover'],
+        ];
+    }
+
+    /**
+     * @dataProvider columnAttributeKeysProvider
+     */
+    public function testRewriteColumnNestedAttributes(string $key): void
+    {
+        $src = $this->uploadUrl('2024/01/column-bg.jpg');
+        $result = $this->module->rewriteColumnAttributes([
+            $key => [['bgImg' => $src]],
+        ]);
+        $this->assertCloudinaryUrl($result[$key][0]['bgImg'], 'column-bg.jpg');
+    }
+
+    public function testEmptyAttributesPassThrough(): void
+    {
+        $this->assertEquals([], $this->module->rewriteRowLayoutAttributes([]));
+        $this->assertEquals([], $this->module->rewriteColumnAttributes([]));
+    }
+}

--- a/tests/ContentPartialBlockModuleTest.php
+++ b/tests/ContentPartialBlockModuleTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Parent\Modules\ContentPartial\ContentPartialService;
+use Sitchco\Parent\Modules\ContentPartialBlock\ContentPartialBlockModule;
+use Sitchco\Tests\TestCase;
+
+class ContentPartialBlockModuleTest extends TestCase
+{
+    protected ContentPartialBlockModule $module;
+    protected ContentPartialService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = $this->container->get(ContentPartialBlockModule::class);
+        $this->service = $this->container->get(ContentPartialService::class);
+    }
+
+    private function getTemplateAreas(): array
+    {
+        $reflection = new \ReflectionClass($this->service);
+        $prop = $reflection->getProperty('templateAreas');
+        $prop->setAccessible(true);
+        return $prop->getValue($this->service);
+    }
+
+    public function testInitAddsBlockTemplateAreaWithoutContext(): void
+    {
+        $areas = $this->getTemplateAreas();
+        $this->assertArrayHasKey('block', $areas);
+        $this->assertFalse($areas['block']);
+    }
+}

--- a/tests/ContentPartialBlockModuleTest.php
+++ b/tests/ContentPartialBlockModuleTest.php
@@ -18,17 +18,9 @@ class ContentPartialBlockModuleTest extends TestCase
         $this->service = $this->container->get(ContentPartialService::class);
     }
 
-    private function getTemplateAreas(): array
-    {
-        $reflection = new \ReflectionClass($this->service);
-        $prop = $reflection->getProperty('templateAreas');
-        $prop->setAccessible(true);
-        return $prop->getValue($this->service);
-    }
-
     public function testInitAddsBlockTemplateAreaWithoutContext(): void
     {
-        $areas = $this->getTemplateAreas();
+        $areas = $this->service->getTemplateAreas();
         $this->assertArrayHasKey('block', $areas);
         $this->assertFalse($areas['block']);
     }

--- a/tests/ContentPartialModuleTest.php
+++ b/tests/ContentPartialModuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Parent\Modules\ContentPartial\ContentPartialModule;
+use Sitchco\Parent\Modules\ContentPartial\ContentPartialPost;
+use Sitchco\Tests\TestCase;
+
+class ContentPartialModuleTest extends TestCase
+{
+    protected ContentPartialModule $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = $this->container->get(ContentPartialModule::class);
+    }
+
+    /**
+     * @dataProvider makeSlugEditableProvider
+     */
+    public function testMakeSlugEditable(bool $currentValue, string $postType, bool $expected): void
+    {
+        $postTypeObject = get_post_type_object($postType);
+        $result = $this->module->makeSlugEditable($currentValue, $postTypeObject);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public static function makeSlugEditableProvider(): array
+    {
+        return [
+            'returns true for content-partial' => [false, ContentPartialPost::POST_TYPE, true],
+            'passes through false for other types' => [false, 'post', false],
+            'preserves existing true for other types' => [true, 'post', true],
+        ];
+    }
+}

--- a/tests/ContentPartialServiceTest.php
+++ b/tests/ContentPartialServiceTest.php
@@ -144,9 +144,12 @@ class ContentPartialServiceTest extends TestCase
         Cache::forget('content_partial_term_header');
 
         $firstResult = $this->service->getTermId('header');
-        $secondResult = $this->service->getTermId('header');
-
         $this->assertNotNull($firstResult);
+
+        wp_cache_get('content_partial_term_header', 'sitchco', false, $found);
+        $this->assertTrue($found, 'Expected getTermId result to be stored in object cache');
+
+        $secondResult = $this->service->getTermId('header');
         $this->assertSame($firstResult, $secondResult);
     }
 

--- a/tests/ContentPartialServiceTest.php
+++ b/tests/ContentPartialServiceTest.php
@@ -7,10 +7,8 @@ use Sitchco\Parent\Modules\ContentPartial\ContentPartialRepository;
 use Sitchco\Parent\Modules\ContentPartial\ContentPartialService;
 use Sitchco\Parent\Tests\Support\ModuleTester;
 use Sitchco\Tests\TestCase;
+use Sitchco\Utils\Cache;
 
-/**
- * class ContentPartialServiceTestnamespace SitchcoParentModulesSiteHeader;
- */
 class ContentPartialServiceTest extends TestCase
 {
     protected ContentPartialService $service;
@@ -23,14 +21,39 @@ class ContentPartialServiceTest extends TestCase
         $this->service = $this->container->get(ContentPartialService::class);
         $this->repository = $this->container->get(ContentPartialRepository::class);
 
-        // Create a default content partial with a taxonomy term
-        $this->standardHeaderId = $this->factory()->post->create([
+        $this->standardHeaderId = $this->createContentPartial('header', [
             'post_title' => 'Standard Header',
-            'post_type' => ContentPartialPost::POST_TYPE,
             'meta_input' => ['is_default' => '1'],
         ]);
+    }
 
-        wp_set_object_terms($this->standardHeaderId, 'header', ContentPartialPost::TAXONOMY);
+    private function createContentPartial(string $term, array $overrides = []): int
+    {
+        $postId = $this->factory()->post->create(
+            array_merge(
+                [
+                    'post_type' => ContentPartialPost::POST_TYPE,
+                ],
+                $overrides,
+            ),
+        );
+        wp_set_object_terms($postId, $term, ContentPartialPost::TAXONOMY);
+        return $postId;
+    }
+
+    private function createPageWithPartialOverride(string $area, int $partialId): int
+    {
+        $pageId = $this->factory()->post->create([
+            'post_type' => 'page',
+            'post_title' => 'Test Page',
+        ]);
+        update_field("{$area}_partial", $partialId, $pageId);
+        return $pageId;
+    }
+
+    private function makeFreshService(): ContentPartialService
+    {
+        return new ContentPartialService($this->repository);
     }
 
     public function testFindDefaultPartial(): void
@@ -47,28 +70,105 @@ class ContentPartialServiceTest extends TestCase
         $taxonomy = ContentPartialPost::TAXONOMY;
         $termSlug = 'sidebar';
 
-        // Ensure taxonomy exists
         $this->assertTrue(taxonomy_exists($taxonomy));
-
-        // Ensure the term does not exist before running the function
         $this->assertNull(term_exists($termSlug, $taxonomy));
 
         $Module = $this->container->get(ModuleTester::class);
-        // Register the new module, which should create the term
         $Module->init();
 
-        // Simulate running ensureTaxonomyTermExists in a real admin context
         global $current_screen;
         $current_screen = convert_to_screen(ContentPartialPost::POST_TYPE);
         $this->service->ensureTaxonomyTermExists($current_screen);
 
-        // Verify the term now exists
         $term = term_exists($termSlug, $taxonomy);
         $this->assertIsArray($term);
         $this->assertArrayHasKey('term_id', $term);
 
-        // Ensure the term's name is properly capitalized
         $termData = get_term($term['term_id']);
         $this->assertEquals('Sidebar', $termData->name);
+    }
+
+    public function testSetContextResolvesDefaultPartial(): void
+    {
+        $service = $this->makeFreshService();
+        $service->addTemplateArea('header');
+        $service->setContext();
+
+        $result = $service->getPartial('header');
+        $this->assertInstanceOf(ContentPartialPost::class, $result);
+        $this->assertEquals($this->standardHeaderId, $result->ID);
+    }
+
+    public function testSetContextOverrideTakesPrecedence(): void
+    {
+        $overrideId = $this->factory()->post->create([
+            'post_title' => 'Override Header',
+            'post_type' => ContentPartialPost::POST_TYPE,
+        ]);
+
+        $pageId = $this->createPageWithPartialOverride('header', $overrideId);
+
+        $service = $this->makeFreshService();
+        $service->addTemplateArea('header');
+
+        $GLOBALS['wp_query']->queried_object_id = $pageId;
+        $GLOBALS['wp_query']->queried_object = get_post($pageId);
+
+        $service->setContext();
+
+        $result = $service->getPartial('header');
+        $this->assertInstanceOf(ContentPartialPost::class, $result);
+        $this->assertEquals($overrideId, $result->ID);
+    }
+
+    public function testSetContextSkipsAreasWithoutContext(): void
+    {
+        $service = $this->makeFreshService();
+        $service->addTemplateArea('header', false);
+        $service->setContext();
+
+        $this->assertNull($service->getPartial('header'));
+    }
+
+    public function testSetContextSkipsAreaWithNoMatchingPartial(): void
+    {
+        $service = $this->makeFreshService();
+        $service->addTemplateArea('footer');
+        $service->setContext();
+
+        $this->assertNull($service->getPartial('footer'));
+    }
+
+    public function testGetTermIdCachesResult(): void
+    {
+        Cache::forget('content_partial_term_header');
+
+        $firstResult = $this->service->getTermId('header');
+        $secondResult = $this->service->getTermId('header');
+
+        $this->assertNotNull($firstResult);
+        $this->assertSame($firstResult, $secondResult);
+    }
+
+    public function testFindPartialOverrideFromPage(): void
+    {
+        $partialId = $this->factory()->post->create([
+            'post_title' => 'Override Header',
+            'post_type' => ContentPartialPost::POST_TYPE,
+        ]);
+
+        $pageId = $this->createPageWithPartialOverride('header', $partialId);
+
+        $result = $this->repository->findPartialOverrideFromPage('header', $pageId);
+        $this->assertInstanceOf(ContentPartialPost::class, $result);
+        $this->assertEquals($partialId, $result->ID);
+    }
+
+    public function testFindPartialOverrideReturnsNullWhenNoPage(): void
+    {
+        $GLOBALS['wp_query']->queried_object_id = 0;
+
+        $result = $this->repository->findPartialOverrideFromPage('header');
+        $this->assertNull($result);
     }
 }

--- a/tests/ContentSliderTest.php
+++ b/tests/ContentSliderTest.php
@@ -7,12 +7,10 @@ use Sitchco\Tests\TestCase;
 
 class ContentSliderTest extends TestCase
 {
-    protected ContentSlider $module;
-
     protected function setUp(): void
     {
         parent::setUp();
-        $this->module = $this->container->get(ContentSlider::class);
+        $this->container->get(ContentSlider::class);
     }
 
     public function testScanVariationsFindsValidFiles(): void
@@ -21,7 +19,7 @@ class ContentSliderTest extends TestCase
         if (!is_dir($variationsDir)) {
             $this->markTestSkipped('Variations directory does not exist');
         }
-        $variations = $this->module->scanVariations();
+        $variations = apply_filters(ContentSlider::hookName('variations'), []);
         $this->assertIsArray($variations);
         $this->assertNotEmpty($variations, 'Expected at least one variation file on disk');
 
@@ -47,7 +45,7 @@ class ContentSliderTest extends TestCase
         wp_cache_delete('content_slider_variations');
 
         try {
-            $variations = $this->module->scanVariations();
+            $variations = apply_filters(ContentSlider::hookName('variations'), []);
             $this->assertArrayNotHasKey('test-bad-variation', $variations);
         } finally {
             unlink($invalidFile);
@@ -57,13 +55,18 @@ class ContentSliderTest extends TestCase
 
     public function testVariationsFilterMergesScannedVariations(): void
     {
-        $hookName = ContentSlider::hookName('variations');
-        $filtered = apply_filters($hookName, []);
-        $scanned = $this->module->scanVariations();
+        $variationsDir = get_template_directory() . '/modules/ContentSlider/variations';
+        if (!is_dir($variationsDir)) {
+            $this->markTestSkipped('Variations directory does not exist');
+        }
+        $filtered = apply_filters(ContentSlider::hookName('variations'), []);
         $this->assertIsArray($filtered);
+        $this->assertNotEmpty($filtered, 'Expected variations to be merged into filter output');
 
-        foreach ($scanned as $slug => $config) {
-            $this->assertArrayHasKey($slug, $filtered, "Scanned variation '{$slug}' missing from filter output");
+        foreach ($filtered as $slug => $config) {
+            $this->assertIsString($slug);
+            $this->assertArrayHasKey('title', $config);
+            $this->assertArrayHasKey('splide', $config);
         }
     }
 }

--- a/tests/ContentSliderTest.php
+++ b/tests/ContentSliderTest.php
@@ -4,6 +4,7 @@ namespace Sitchco\Parent\Tests;
 
 use Sitchco\Parent\Modules\ContentSlider\ContentSlider;
 use Sitchco\Tests\TestCase;
+use Sitchco\Utils\Cache;
 
 class ContentSliderTest extends TestCase
 {
@@ -42,14 +43,14 @@ class ContentSliderTest extends TestCase
         file_put_contents($invalidFile, json_encode(['title' => 'Bad Variation']));
 
         // Clear the cache so scanVariations re-reads the filesystem
-        wp_cache_delete('content_slider_variations');
+        Cache::forget('content_slider_variations');
 
         try {
             $variations = apply_filters(ContentSlider::hookName('variations'), []);
             $this->assertArrayNotHasKey('test-bad-variation', $variations);
         } finally {
             unlink($invalidFile);
-            wp_cache_delete('content_slider_variations');
+            Cache::forget('content_slider_variations');
         }
     }
 

--- a/tests/ContentSliderTest.php
+++ b/tests/ContentSliderTest.php
@@ -15,21 +15,13 @@ class ContentSliderTest extends TestCase
         $this->module = $this->container->get(ContentSlider::class);
     }
 
-    private function invokeScanVariations(): array
-    {
-        $reflection = new \ReflectionClass($this->module);
-        $method = $reflection->getMethod('scanVariations');
-        $method->setAccessible(true);
-        return $method->invoke($this->module);
-    }
-
     public function testScanVariationsFindsValidFiles(): void
     {
         $variationsDir = get_template_directory() . '/modules/ContentSlider/variations';
         if (!is_dir($variationsDir)) {
             $this->markTestSkipped('Variations directory does not exist');
         }
-        $variations = $this->invokeScanVariations();
+        $variations = $this->module->scanVariations();
         $this->assertIsArray($variations);
         $this->assertNotEmpty($variations, 'Expected at least one variation file on disk');
 
@@ -55,7 +47,7 @@ class ContentSliderTest extends TestCase
         wp_cache_delete('content_slider_variations');
 
         try {
-            $variations = $this->invokeScanVariations();
+            $variations = $this->module->scanVariations();
             $this->assertArrayNotHasKey('test-bad-variation', $variations);
         } finally {
             unlink($invalidFile);
@@ -67,7 +59,7 @@ class ContentSliderTest extends TestCase
     {
         $hookName = ContentSlider::hookName('variations');
         $filtered = apply_filters($hookName, []);
-        $scanned = $this->invokeScanVariations();
+        $scanned = $this->module->scanVariations();
         $this->assertIsArray($filtered);
 
         foreach ($scanned as $slug => $config) {

--- a/tests/ContentSliderTest.php
+++ b/tests/ContentSliderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Parent\Modules\ContentSlider\ContentSlider;
+use Sitchco\Tests\TestCase;
+
+class ContentSliderTest extends TestCase
+{
+    protected ContentSlider $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = $this->container->get(ContentSlider::class);
+    }
+
+    private function invokeScanVariations(): array
+    {
+        $reflection = new \ReflectionClass($this->module);
+        $method = $reflection->getMethod('scanVariations');
+        $method->setAccessible(true);
+        return $method->invoke($this->module);
+    }
+
+    public function testScanVariationsFindsValidFiles(): void
+    {
+        $variationsDir = get_template_directory() . '/modules/ContentSlider/variations';
+        if (!is_dir($variationsDir)) {
+            $this->markTestSkipped('Variations directory does not exist');
+        }
+        $variations = $this->invokeScanVariations();
+        $this->assertIsArray($variations);
+        $this->assertNotEmpty($variations, 'Expected at least one variation file on disk');
+
+        foreach ($variations as $slug => $config) {
+            $this->assertIsString($slug);
+            $this->assertArrayHasKey('title', $config);
+            $this->assertArrayHasKey('splide', $config);
+        }
+    }
+
+    public function testScanVariationsSkipsInvalidFiles(): void
+    {
+        $dir = get_template_directory() . '/modules/ContentSlider/variations';
+        if (!is_dir($dir)) {
+            $this->markTestSkipped('Variations directory does not exist');
+        }
+
+        // Create a file missing the required 'splide' key
+        $invalidFile = $dir . '/test-bad-variation.json';
+        file_put_contents($invalidFile, json_encode(['title' => 'Bad Variation']));
+
+        // Clear the cache so scanVariations re-reads the filesystem
+        wp_cache_delete('content_slider_variations');
+
+        try {
+            $variations = $this->invokeScanVariations();
+            $this->assertArrayNotHasKey('test-bad-variation', $variations);
+        } finally {
+            unlink($invalidFile);
+            wp_cache_delete('content_slider_variations');
+        }
+    }
+
+    public function testVariationsFilterMergesScannedVariations(): void
+    {
+        $hookName = ContentSlider::hookName('variations');
+        $filtered = apply_filters($hookName, []);
+        $scanned = $this->invokeScanVariations();
+        $this->assertIsArray($filtered);
+
+        foreach ($scanned as $slug => $config) {
+            $this->assertArrayHasKey($slug, $filtered, "Scanned variation '{$slug}' missing from filter output");
+        }
+    }
+}

--- a/tests/ExtendBlockModuleTest.php
+++ b/tests/ExtendBlockModuleTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Parent\Modules\ExtendBlock\ExtendBlockModule;
+use Sitchco\Tests\TestCase;
+
+class ExtendBlockModuleTest extends TestCase
+{
+    protected ExtendBlockModule $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = $this->container->get(ExtendBlockModule::class);
+    }
+
+    /**
+     * @dataProvider earlyReturnProvider
+     */
+    public function testReturnsUnchangedWhenNoMeaningfulClasses(array $attrs): void
+    {
+        $html = '<div class="wp-block-group">content</div>';
+        $block = ['attrs' => $attrs, 'blockName' => 'core/group'];
+        $this->assertSame($html, $this->module->injectExtendBlockClasses($html, $block));
+    }
+
+    public static function earlyReturnProvider(): array
+    {
+        return [
+            'no attrs' => [[]],
+            'empty array' => [['extendBlockClasses' => []]],
+            'whitespace only' => [['extendBlockClasses' => ['ns1' => '   ']]],
+            'empty string legacy' => [['extendBlockClasses' => '']],
+        ];
+    }
+
+    public function testInjectsClassesFromObjectFormatIntoExistingClassAttribute(): void
+    {
+        $html = '<div class="wp-block-group">content</div>';
+        $block = [
+            'attrs' => ['extendBlockClasses' => ['ns1' => 'custom-class']],
+            'blockName' => 'core/group',
+        ];
+        $result = $this->module->injectExtendBlockClasses($html, $block);
+        $this->assertSame('<div class="wp-block-group custom-class">content</div>', $result);
+    }
+
+    public function testInjectsClassesFromMultipleNamespaces(): void
+    {
+        $html = '<div class="wp-block-group">content</div>';
+        $block = [
+            'attrs' => ['extendBlockClasses' => ['ns1' => 'class-a', 'ns2' => 'class-b']],
+            'blockName' => 'core/group',
+        ];
+        $result = $this->module->injectExtendBlockClasses($html, $block);
+        $this->assertSame('<div class="wp-block-group class-a class-b">content</div>', $result);
+    }
+
+    public function testMixedEmptyAndNonEmptyNamespaces(): void
+    {
+        $html = '<div class="wp-block-group">content</div>';
+        $block = [
+            'attrs' => ['extendBlockClasses' => ['ns1' => '', 'ns2' => 'real-class']],
+            'blockName' => 'core/group',
+        ];
+        $result = $this->module->injectExtendBlockClasses($html, $block);
+        $this->assertSame('<div class="wp-block-group real-class">content</div>', $result);
+    }
+
+    public function testCreatesClassAttributeWhenMissing(): void
+    {
+        $html = '<div>content</div>';
+        $block = [
+            'attrs' => ['extendBlockClasses' => ['ns1' => 'injected-class']],
+            'blockName' => 'core/group',
+        ];
+        $result = $this->module->injectExtendBlockClasses($html, $block);
+        $this->assertStringContainsString('class="injected-class"', $result);
+    }
+
+    public function testInjectsClassesFromLegacyStringFormat(): void
+    {
+        $html = '<div class="wp-block-group">content</div>';
+        $block = [
+            'attrs' => ['extendBlockClasses' => 'legacy-class'],
+            'blockName' => 'core/group',
+        ];
+        $result = $this->module->injectExtendBlockClasses($html, $block);
+        $this->assertSame('<div class="wp-block-group legacy-class">content</div>', $result);
+    }
+
+    public function testFilterCanExcludeNamespace(): void
+    {
+        $hookName = ExtendBlockModule::hookName('inject-classes');
+        $callback = function (array $classes) {
+            unset($classes['excluded-ns']);
+            return $classes;
+        };
+        add_filter($hookName, $callback);
+
+        $html = '<div class="wp-block-group">content</div>';
+        $block = [
+            'attrs' => ['extendBlockClasses' => ['kept-ns' => 'keep-me', 'excluded-ns' => 'remove-me']],
+            'blockName' => 'core/group',
+        ];
+        $result = $this->module->injectExtendBlockClasses($html, $block);
+
+        $this->assertSame('<div class="wp-block-group keep-me">content</div>', $result);
+
+        remove_filter($hookName, $callback);
+    }
+
+    public function testClassesAreSanitizedViaEscAttr(): void
+    {
+        $html = '<div class="wp-block-group">content</div>';
+        $block = [
+            'attrs' => ['extendBlockClasses' => ['ns1' => '" onclick="alert(1)']],
+            'blockName' => 'core/group',
+        ];
+        $result = $this->module->injectExtendBlockClasses($html, $block);
+        // esc_attr converts quotes to &quot;, preventing attribute injection
+        $this->assertStringContainsString('&quot;', $result);
+        $this->assertStringNotContainsString('onclick="alert', $result);
+    }
+
+    public function testHtmlCommentsBeforeElementArePreserved(): void
+    {
+        $html = '<!-- wp:group --><div class="wp-block-group">content</div>';
+        $block = [
+            'attrs' => ['extendBlockClasses' => ['ns1' => 'added']],
+            'blockName' => 'core/group',
+        ];
+        $result = $this->module->injectExtendBlockClasses($html, $block);
+        $this->assertSame('<!-- wp:group --><div class="wp-block-group added">content</div>', $result);
+    }
+}

--- a/tests/GravityFormsTest.php
+++ b/tests/GravityFormsTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Parent\Modules\GravityForms\GravityForms;
+use Sitchco\Tests\TestCase;
+
+class GravityFormsTest extends TestCase
+{
+    protected GravityForms $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = $this->container->get(GravityForms::class);
+    }
+
+    // --- hideBlockStyleControls ---
+
+    public function testHideBlockStyleControlsSetsOrbitalDefaultToFalse(): void
+    {
+        $config = [
+            'block_editor' => [
+                'gravityforms/form' => [
+                    'data' => ['orbitalDefault' => true, 'other' => 'value'],
+                ],
+            ],
+        ];
+        $result = $this->module->hideBlockStyleControls($config);
+        $this->assertFalse($result['block_editor']['gravityforms/form']['data']['orbitalDefault']);
+        $this->assertSame('value', $result['block_editor']['gravityforms/form']['data']['other']);
+    }
+
+    public function testHideBlockStyleControlsPassesThroughConfigWithoutGfBlock(): void
+    {
+        $config = ['block_editor' => ['core/paragraph' => ['data' => ['foo' => 'bar']]]];
+        $this->assertSame($config, $this->module->hideBlockStyleControls($config));
+    }
+
+    // --- bridgeInlineStyles ---
+
+    /**
+     * @dataProvider bridgeInlineStylesProvider
+     */
+    public function testBridgeInlineStyles(string $input, string $expected): void
+    {
+        $this->assertSame($expected, $this->module->bridgeInlineStyles($input));
+    }
+
+    public static function bridgeInlineStylesProvider(): array
+    {
+        return [
+            'color primary bridged' => [
+                '--gf-color-primary: #204ce5;',
+                '--gf-color-primary: var(--wp--custom--gf--color-primary, #204ce5);',
+            ],
+            'border color bridged' => [
+                '--gf-ctrl-border-color: #ccc;',
+                '--gf-ctrl-border-color: var(--wp--custom--gf--ctrl-border-color, #ccc);',
+            ],
+            'icon property skipped' => [
+                '--gf-icon-chevron: url(data:image/svg+xml;base64,abc);',
+                '--gf-icon-chevron: url(data:image/svg+xml;base64,abc);',
+            ],
+            'no gf vars unchanged' => ['--color-primary: blue;', '--color-primary: blue;'],
+            'multiple vars all bridged' => [
+                '--gf-color-primary: #204ce5; --gf-color-secondary: #333;',
+                '--gf-color-primary: var(--wp--custom--gf--color-primary, #204ce5); --gf-color-secondary: var(--wp--custom--gf--color-secondary, #333);',
+            ],
+        ];
+    }
+
+    // --- replaceSubmitButton ---
+
+    public function testReplaceSubmitButtonConvertsInputToButton(): void
+    {
+        $input = '<input type="submit" id="gform_submit_button_1" value="Send Message" />';
+        $form = ['id' => 1];
+        $result = $this->module->replaceSubmitButton($input, $form);
+        $this->assertStringContainsString('<button type="submit"', $result);
+        $this->assertStringContainsString('wp-block-button__link', $result);
+        $this->assertStringContainsString('Send Message', $result);
+        $this->assertStringContainsString('id="gform_submit_button_1"', $result);
+        $this->assertStringContainsString('<div class=', $result);
+    }
+
+    public function testReplaceSubmitButtonPreservesDataAttributes(): void
+    {
+        $input = '<input type="submit" value="Submit" data-loading="Sending..." tabindex="5" />';
+        $form = ['id' => 1];
+        $result = $this->module->replaceSubmitButton($input, $form);
+        $this->assertStringContainsString('data-loading="Sending..."', $result);
+        $this->assertStringContainsString('tabindex="5"', $result);
+    }
+
+    public function testReplaceSubmitButtonHandlesButtonElement(): void
+    {
+        $input =
+            '<button type="submit" id="gform_submit_button_1" class="gform_button"><svg><path d="M0 0"/></svg>Submit Now</button>';
+        $form = ['id' => 1];
+        $result = $this->module->replaceSubmitButton($input, $form);
+        $this->assertStringContainsString('<button type="submit"', $result);
+        $this->assertStringContainsString('wp-block-button__link', $result);
+        $this->assertStringContainsString('Submit Now', $result);
+        // SVG should be stripped from the button text
+        $this->assertStringNotContainsString('<svg', $result);
+    }
+
+    // --- registerBlockAttributes ---
+
+    public function testRegisterBlockAttributesAddsCustomAttrsForGravityFormsBlock(): void
+    {
+        $args = ['attributes' => []];
+        $result = $this->module->registerBlockAttributes($args, 'gravityforms/form');
+        $this->assertArrayHasKey('theme', $result['attributes']);
+        $this->assertArrayHasKey('icon', $result['attributes']);
+        $this->assertArrayHasKey('extendBlockClasses', $result['attributes']);
+    }
+
+    public function testRegisterBlockAttributesPassesThroughOtherBlocks(): void
+    {
+        $args = ['attributes' => ['existing' => true]];
+        $result = $this->module->registerBlockAttributes($args, 'core/paragraph');
+        $this->assertSame($args, $result);
+    }
+
+    // --- prepareButtonThemeClass + applyButtonThemeClass ---
+
+    public function testPrepareAndApplyButtonThemeClassWithThemeAndIcon(): void
+    {
+        $block = [
+            'blockName' => 'gravityforms/form',
+            'attrs' => ['theme' => 'arrow', 'icon' => 'chevron'],
+        ];
+        $this->module->prepareButtonThemeClass($block);
+        $result = $this->module->applyButtonThemeClass(['wp-block-button']);
+
+        $this->assertContains('has-theme-arrow', $result);
+        $this->assertContains('has-icon', $result);
+        $this->assertContains('has-icon-chevron', $result);
+        $this->assertContains('wp-block-button', $result);
+    }
+
+    public function testPrepareAndApplyButtonThemeClassClearsStateAfterApply(): void
+    {
+        $block = [
+            'blockName' => 'gravityforms/form',
+            'attrs' => ['theme' => 'arrow'],
+        ];
+        $this->module->prepareButtonThemeClass($block);
+        $this->module->applyButtonThemeClass([]);
+
+        // Second apply without prepare should return only the existing classes
+        $result = $this->module->applyButtonThemeClass(['wp-block-button']);
+        $this->assertSame(['wp-block-button'], $result);
+    }
+
+    public function testPrepareButtonThemeClassSkipsNonGravityFormsBlocks(): void
+    {
+        $block = [
+            'blockName' => 'core/paragraph',
+            'attrs' => ['theme' => 'arrow'],
+        ];
+        $this->module->prepareButtonThemeClass($block);
+        $result = $this->module->applyButtonThemeClass(['wp-block-button']);
+        $this->assertSame(['wp-block-button'], $result);
+    }
+
+    public function testPrepareButtonThemeClassWithNoThemeOrIcon(): void
+    {
+        $block = [
+            'blockName' => 'gravityforms/form',
+            'attrs' => [],
+        ];
+        $this->module->prepareButtonThemeClass($block);
+        $result = $this->module->applyButtonThemeClass(['wp-block-button']);
+        $this->assertSame(['wp-block-button'], $result);
+    }
+
+    // --- replacePaginationButton ---
+
+    public function testReplacePaginationButtonConvertsInputToButton(): void
+    {
+        $input =
+            '<input type="button" value="Next" class="gform_next_button" id="gform_next_button_1_2" onclick="jQuery(this).closest(\'form\').submit();" />';
+        $form = ['id' => 1];
+        $result = $this->module->replacePaginationButton($input, $form);
+        $this->assertStringContainsString('<button type="button"', $result);
+        $this->assertStringContainsString('>Next</button>', $result);
+        $this->assertStringContainsString('gform_page_button_wrapper', $result);
+        $this->assertStringContainsString('class="gform_next_button"', $result);
+        $this->assertStringContainsString('onclick=', $result);
+    }
+
+    public function testReplacePaginationButtonPassesThroughExistingButton(): void
+    {
+        $html = '<button class="gform_next_button" type="button">Next</button>';
+        $form = ['id' => 1];
+        $this->assertSame($html, $this->module->replacePaginationButton($html, $form));
+    }
+}

--- a/tests/KadenceBlocksTest.php
+++ b/tests/KadenceBlocksTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Parent\Modules\KadenceBlocks\KadenceBlocks;
+use Sitchco\Tests\TestCase;
+
+class KadenceBlocksTest extends TestCase
+{
+    private const TAB_HTML = '<div class="kt-tab-inner-content"><div class="kt-tab-inner-content-inner">content</div></div>';
+
+    private const SPACING_INPUT = [
+        'ss-auto' => 'auto',
+        '0' => '0',
+        'none' => '',
+        'xxs' => '0.25rem',
+        'xs' => '0.5rem',
+        'sm' => '1rem',
+        'md' => '2rem',
+    ];
+
+    protected KadenceBlocks $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = $this->container->get(KadenceBlocks::class);
+    }
+
+    // --- overrideSpacingSizes ---
+
+    public function testOverrideSpacingSizesPreservesDefaultsAndDropsKadenceSlugs(): void
+    {
+        $result = $this->module->overrideSpacingSizes(self::SPACING_INPUT);
+        $this->assertArrayHasKey('ss-auto', $result);
+        $this->assertArrayHasKey('0', $result);
+        $this->assertArrayHasKey('none', $result);
+        $this->assertArrayNotHasKey('xxs', $result);
+        $this->assertArrayNotHasKey('xs', $result);
+        $this->assertArrayNotHasKey('sm', $result);
+        $this->assertArrayNotHasKey('md', $result);
+    }
+
+    public function testOverrideSpacingSizesOutputKeysUseVarFormat(): void
+    {
+        $result = $this->module->overrideSpacingSizes(['xxs' => '0.25rem', 'ss-auto' => 'auto']);
+        foreach ($result as $key => $value) {
+            if (in_array($key, ['ss-auto', '0', 'none'])) {
+                continue;
+            }
+            $this->assertStringStartsWith('spacing-', $key);
+            $this->assertStringStartsWith('var(--wp--preset--spacing--', $value);
+        }
+    }
+
+    // --- overrideGapSizes ---
+
+    public function testOverrideGapSizesIncludesContentFlowToken(): void
+    {
+        $result = $this->module->overrideGapSizes([]);
+        $this->assertArrayHasKey('content-flow', $result);
+        $this->assertSame('var(--wp--custom--block-gap)', $result['content-flow']);
+    }
+
+    // --- overrideFontSizes ---
+
+    public function testOverrideFontSizesDropsNonDefaultAndMapsThemePresets(): void
+    {
+        $result = $this->module->overrideFontSizes(['xxs' => '10px', 'ss-auto' => 'auto']);
+        $this->assertArrayNotHasKey('xxs', $result);
+        foreach ($result as $key => $value) {
+            if (in_array($key, ['ss-auto', '0', 'none'])) {
+                continue;
+            }
+            $this->assertStringStartsWith('font-size-', $key);
+            $this->assertStringStartsWith('var(--wp--preset--font-size--', $value);
+        }
+    }
+
+    // --- overrideConfigDefaults ---
+
+    /**
+     * @dataProvider configDefaultsProvider
+     */
+    public function testOverrideConfigDefaults(mixed $input, mixed $expected): void
+    {
+        $result = $this->module->overrideConfigDefaults($input);
+        $this->assertSame($expected, $result);
+    }
+
+    public static function configDefaultsProvider(): array
+    {
+        return [
+            'empty JSON string becomes valid config' => ['{}', '{"kadence\/tabs":{},"kadence\/accordion":{}}'],
+            'existing config passed through' => ['{"kadence/tabs":{}}', '{"kadence/tabs":{}}'],
+            'false passed through' => [false, false],
+        ];
+    }
+
+    // --- injectDefaultColumnGap ---
+
+    /**
+     * @dataProvider columnGapProvider
+     */
+    public function testInjectDefaultColumnGap(array $input, string $expectedFirstValue): void
+    {
+        $result = $this->module->injectDefaultColumnGap($input);
+        $this->assertSame($expectedFirstValue, $result['rowGapVariable'][0]);
+    }
+
+    public static function columnGapProvider(): array
+    {
+        return [
+            'no rowGapVariable key' => [[], 'content-flow'],
+            'empty first value' => [['rowGapVariable' => ['', '', '']], 'content-flow'],
+            'null first value' => [['rowGapVariable' => [null, '', '']], 'content-flow'],
+            'existing value preserved' => [['rowGapVariable' => ['custom-value', '', '']], 'custom-value'],
+        ];
+    }
+
+    // --- enableCssVariablesForPadding ---
+
+    /**
+     * @dataProvider cssVariablesForPaddingProvider
+     */
+    public function testEnableCssVariablesForPadding(
+        bool $useVariables,
+        string $property,
+        string $selector,
+        bool $expected,
+    ): void {
+        $result = $this->module->enableCssVariablesForPadding($useVariables, $property, '', $selector, []);
+        $this->assertSame($expected, $result);
+    }
+
+    public static function cssVariablesForPaddingProvider(): array
+    {
+        return [
+            'padding + kadence-column' => [false, 'padding', '.kadence-column .inner', true],
+            'padding + kb-row-layout' => [false, 'padding', '.kb-row-layout', true],
+            'padding + wp-block-kadence-tab' => [false, 'padding', '.wp-block-kadence-tab', true],
+            'padding + other selector' => [false, 'padding', '.some-other-class', false],
+            'margin + kadence-column' => [false, 'margin', '.kadence-column', false],
+            'padding + kadence-column with useVariables true' => [true, 'padding', '.kadence-column', true],
+            'non-matching passes through useVariables' => [true, 'margin', '.some-class', true],
+        ];
+    }
+
+    // --- addTabFullWidthContentClasses ---
+
+    public function testAddTabFullWidthContentClassesAddsLayoutClass(): void
+    {
+        $block = ['attrs' => ['fullWidthContent' => true]];
+        $result = $this->module->addTabFullWidthContentClasses(self::TAB_HTML, $block);
+        $this->assertStringContainsString('is-layout-constrained', $result);
+    }
+
+    public function testAddTabFullWidthContentClassesSkipsWhenDisabled(): void
+    {
+        $block = ['attrs' => []];
+        $result = $this->module->addTabFullWidthContentClasses(self::TAB_HTML, $block);
+        $this->assertStringNotContainsString('is-layout-constrained', $result);
+    }
+
+    // --- handleRowCssMaxWidth ---
+
+    /**
+     * @dataProvider handleRowCssMaxWidthProvider
+     */
+    public function testHandleRowCssMaxWidth(bool $skip, string $innerContentWidth, bool $expected): void
+    {
+        $result = $this->module->handleRowCssMaxWidth(
+            $skip,
+            ['innerContentWidth' => $innerContentWidth],
+            'uid',
+            '.selector',
+        );
+        $this->assertSame($expected, $result);
+    }
+
+    public static function handleRowCssMaxWidthProvider(): array
+    {
+        return [
+            'preset width skips' => [false, 'theme', true],
+            'wide preset skips' => [false, 'wide', true],
+            'custom does not skip' => [false, 'custom', false],
+            'empty does not skip' => [false, '', false],
+            'unknown preset does not skip' => [false, 'bogus', false],
+            'passthrough preserves existing skip=true' => [true, '', true],
+        ];
+    }
+
+    // --- getContentWidthPresets ---
+
+    public function testGetContentWidthPresetsReturnsExpectedStructure(): void
+    {
+        $result = $this->module->getContentWidthPresets();
+        $this->assertArrayHasKey('theme', $result);
+        $this->assertArrayHasKey('wide', $result);
+        $this->assertArrayHasKey('label', $result['theme']);
+        $this->assertArrayHasKey('label', $result['wide']);
+    }
+}

--- a/tests/PatternContentSanitizerTest.php
+++ b/tests/PatternContentSanitizerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sitchco\Parent\Modules\Patterns\PatternContentSanitizer;
+
+class PatternContentSanitizerTest extends TestCase
+{
+    private PatternContentSanitizer $sanitizer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sanitizer = new PatternContentSanitizer();
+    }
+
+    // --- sanitizePatternContent ---
+
+    /**
+     * @dataProvider sanitizePatternContentProvider
+     */
+    public function testSanitizePatternContent(
+        string $input,
+        string $containsExpected,
+        ?string $notContainsExpected = null,
+    ): void {
+        $result = $this->sanitizer->sanitizePatternContent($input);
+        $this->assertStringContainsString($containsExpected, $result);
+        if ($notContainsExpected !== null) {
+            $this->assertStringNotContainsString($notContainsExpected, $result);
+        }
+    }
+
+    public static function sanitizePatternContentProvider(): array
+    {
+        $placeholder = 'https://cdn.sitch.co/rtc/placeholder-image.png';
+        $videoPlaceholder = 'https://cdn.sitch.co/rtc/placeholder-video.mp4';
+        return [
+            'bgImg URL replaced' => [
+                '"bgImg":"https://example.com/image.jpg"',
+                '"bgImg":"' . $placeholder . '"',
+                'example.com',
+            ],
+            'bgImgID replaced with 0' => ['"bgImgID":42', '"bgImgID":0'],
+            'video local URL replaced' => [
+                '"local":"https://example.com/video.mp4"',
+                '"local":"' . $videoPlaceholder . '"',
+                'example.com',
+            ],
+            'youtube URL cleared' => ['"youTube":"https://youtube.com/watch?v=abc"', '"youTube":""', 'youtube.com'],
+            'vimeo URL cleared' => ['"vimeo":"https://vimeo.com/123"', '"vimeo":""', 'vimeo.com'],
+            'img src replaced' => [
+                '<img src="https://example.com/photo.jpg" alt="Photo">',
+                'src="' . $placeholder . '"',
+                'example.com/photo.jpg',
+            ],
+            'alt text cleared' => [
+                '<img src="placeholder.jpg" alt="A beautiful photo">',
+                'alt=""',
+                'A beautiful photo',
+            ],
+            'http href replaced with #' => ['<a href="https://example.com/page">Link</a>', 'href="#"', 'example.com'],
+            'heading id removed' => [
+                '<h2 id="my-heading" class="wp-block-heading">Title</h2>',
+                '<h2 class="wp-block-heading">',
+                'id="my-heading"',
+            ],
+            'anchor target removed' => [
+                '<a href="#" target="_blank" rel="noopener">Link</a>',
+                '<a href="#"',
+                'target="_blank"',
+            ],
+        ];
+    }
+
+    public function testSanitizePatternContentReplacesTextWithLoremIpsum(): void
+    {
+        $input = '<p>This is some real content text</p>';
+        $result = $this->sanitizer->sanitizePatternContent($input);
+        $this->assertStringContainsString('<p>', $result);
+        $this->assertStringContainsString('</p>', $result);
+        $this->assertStringNotContainsString('This is some real content text', $result);
+        preg_match('/<p>(.+?)<\/p>/', $result, $matches);
+        $this->assertNotEmpty($matches[1]);
+        $this->assertTrue(ctype_upper($matches[1][0]));
+    }
+
+    public function testSanitizePatternContentPreservesNonHttpHrefs(): void
+    {
+        $input = '<a href="#anchor">Link</a>';
+        $result = $this->sanitizer->sanitizePatternContent($input);
+        $this->assertStringContainsString('href="#anchor"', $result);
+    }
+
+    public function testSanitizePatternContentReplacesButtonText(): void
+    {
+        $input = '<a class="wp-block-button__link" href="#">Click Here</a>';
+        $result = $this->sanitizer->sanitizePatternContent($input);
+        $this->assertStringNotContainsString('Click Here', $result);
+    }
+
+    // --- generateLoremIpsum ---
+
+    public function testGenerateLoremIpsumReturnsCorrectWordCount(): void
+    {
+        $result = $this->sanitizer->generateLoremIpsum(5);
+        $this->assertSame(5, str_word_count($result));
+    }
+
+    public function testGenerateLoremIpsumStartsWithLoremIpsum(): void
+    {
+        $result = $this->sanitizer->generateLoremIpsum(5);
+        $this->assertSame('Lorem ipsum dolor sit amet', $result);
+    }
+
+    public function testGenerateLoremIpsumReturnsEmptyForZero(): void
+    {
+        $this->assertSame('', $this->sanitizer->generateLoremIpsum(0));
+    }
+
+    public function testGenerateLoremIpsumWrapsAroundPool(): void
+    {
+        $result = $this->sanitizer->generateLoremIpsum(70);
+        $this->assertSame(70, str_word_count($result));
+    }
+
+    // --- countWords ---
+
+    /**
+     * @dataProvider countWordsProvider
+     */
+    public function testCountWords(string $input, int $expected): void
+    {
+        $this->assertSame($expected, $this->sanitizer->countWords($input));
+    }
+
+    public static function countWordsProvider(): array
+    {
+        return [
+            'plain text' => ['hello world', 2],
+            'with HTML tags' => ['<strong>hello</strong> world', 2],
+            'empty string' => ['', 0],
+            'HTML entities decoded' => ['hello&nbsp;world test', 3],
+            'only tags' => ['<br/>', 0],
+            'nested tags' => ['<p><em>one</em> <strong>two</strong></p>', 2],
+        ];
+    }
+}

--- a/tests/PatternsModuleTest.php
+++ b/tests/PatternsModuleTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Parent\Modules\Patterns\PatternsModule;
+use Sitchco\Tests\TestCase;
+
+class PatternsModuleTest extends TestCase
+{
+    protected PatternsModule $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = $this->container->get(PatternsModule::class);
+    }
+
+    public function testRegisterPatternCategoriesRegistersAction(): void
+    {
+        $this->module->registerPatternCategories();
+        // Verify the init action was registered (the callback registers categories)
+        $this->assertGreaterThan(0, has_action('init'));
+    }
+}

--- a/tests/PatternsModuleTest.php
+++ b/tests/PatternsModuleTest.php
@@ -2,23 +2,59 @@
 
 namespace Sitchco\Parent\Tests;
 
+use Sitchco\Framework\ConfigRegistry;
 use Sitchco\Parent\Modules\Patterns\PatternsModule;
 use Sitchco\Tests\TestCase;
+use WP_Block_Pattern_Categories_Registry;
 
 class PatternsModuleTest extends TestCase
 {
     protected PatternsModule $module;
+    protected ConfigRegistry $configRegistry;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->module = $this->container->get(PatternsModule::class);
+        $this->configRegistry = $this->container->get(ConfigRegistry::class);
     }
 
-    public function testRegisterPatternCategoriesRegistersAction(): void
+    private function countInitCallbacks(): int
     {
+        global $wp_filter;
+        if (!isset($wp_filter['init'])) {
+            return 0;
+        }
+        $count = 0;
+        foreach ($wp_filter['init']->callbacks as $priority => $callbacks) {
+            $count += count($callbacks);
+        }
+        return $count;
+    }
+
+    public function testRegisterPatternCategoriesWithEmptyConfigAddsNoAction(): void
+    {
+        $categories = $this->configRegistry->load('patternCategories');
+        if (!empty($categories)) {
+            $this->markTestSkipped('patternCategories config is not empty in this environment');
+        }
+        $countBefore = $this->countInitCallbacks();
         $this->module->registerPatternCategories();
-        // Verify the init action was registered (the callback registers categories)
-        $this->assertGreaterThan(0, has_action('init'));
+        $this->assertSame(
+            $countBefore,
+            $this->countInitCallbacks(),
+            'Expected no init action when patternCategories config is empty',
+        );
+    }
+
+    public function testRegisterPatternCategoriesRegistersCategories(): void
+    {
+        $categories = $this->configRegistry->load('patternCategories');
+        if (empty($categories)) {
+            $this->markTestSkipped('patternCategories config is empty — requires child theme config');
+        }
+        $countBefore = $this->countInitCallbacks();
+        $this->module->registerPatternCategories();
+        $this->assertGreaterThan($countBefore, $this->countInitCallbacks(), 'Expected init callback to be registered');
     }
 }

--- a/tests/SavePatternsToThemeTest.php
+++ b/tests/SavePatternsToThemeTest.php
@@ -2,8 +2,10 @@
 
 namespace Sitchco\Parent\Tests;
 
+use Sitchco\Parent\Modules\Patterns\PatternContentSanitizer;
 use Sitchco\Parent\Modules\Patterns\SavePatternsToTheme;
 use Sitchco\Tests\TestCase;
+use WP_REST_Request;
 
 class SavePatternsToThemeTest extends TestCase
 {
@@ -14,8 +16,7 @@ class SavePatternsToThemeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->service = $this->container->get(SavePatternsToTheme::class);
-        $this->service->resetUsedSlugs();
+        $this->service = new SavePatternsToTheme(new PatternContentSanitizer());
         $this->patternsDir = get_stylesheet_directory() . '/patterns';
     }
 
@@ -29,179 +30,68 @@ class SavePatternsToThemeTest extends TestCase
         parent::tearDown();
     }
 
-    // --- generateSlug ---
+    // --- slug generation (tested through savePatternToTheme) ---
 
     /**
      * @dataProvider generateSlugProvider
      */
-    public function testGenerateSlug(string $title, string $expected): void
+    public function testGenerateSlug(string $title, string $expectedFilename): void
     {
-        $this->assertSame($expected, $this->service->generateSlug($title));
+        $post = $this->factory()->post->create_and_get([
+            'post_type' => 'wp_block',
+            'post_title' => $title,
+            'post_content' => '<p>Content</p>',
+        ]);
+
+        $result = $this->service->savePatternToTheme($post->ID);
+        $this->assertSame('created', $result);
+
+        $filepath = $this->patternsDir . '/' . $expectedFilename;
+        $this->createdFiles[] = $filepath;
+        $this->assertFileExists($filepath);
     }
 
     public static function generateSlugProvider(): array
     {
         return [
-            'basic title' => ['My Pattern', 'my-pattern'],
-            'leading numbers stripped' => ['123 Numbered Title', 'numbered-title'],
-            'empty title falls back' => ['', 'pattern'],
-            'only numbers falls back' => ['123', 'pattern'],
-            'dashes only falls back' => ['---', 'pattern'],
+            'basic title' => ['My Pattern', 'my-pattern.php'],
+            'leading numbers stripped' => ['123 Numbered Title', 'numbered-title.php'],
+            'empty title falls back' => ['', 'pattern.php'],
+            'only numbers falls back' => ['123', 'pattern.php'],
         ];
     }
 
     public function testGenerateSlugDeduplicatesWithinBatch(): void
     {
-        $first = $this->service->generateSlug('Same Title');
-        $second = $this->service->generateSlug('Same Title');
-        $third = $this->service->generateSlug('Same Title');
+        $post1 = $this->factory()->post->create_and_get([
+            'post_type' => 'wp_block',
+            'post_title' => 'Duplicate Title',
+            'post_content' => '<p>First</p>',
+        ]);
+        $post2 = $this->factory()->post->create_and_get([
+            'post_type' => 'wp_block',
+            'post_title' => 'Duplicate Title',
+            'post_content' => '<p>Second</p>',
+        ]);
 
-        $this->assertSame('same-title', $first);
-        $this->assertSame('same-title-2', $second);
-        $this->assertSame('same-title-3', $third);
+        $request = new WP_REST_Request('POST', '/theme/v1/save-patterns');
+        $request->set_param('pattern_ids', [$post1->ID, $post2->ID]);
+
+        $response = $this->service->handleRestRequest($request);
+        $data = $response->get_data();
+
+        $this->assertTrue($data['success']);
+        $this->assertCount(2, $data['created']);
+
+        $file1 = $this->patternsDir . '/duplicate-title.php';
+        $file2 = $this->patternsDir . '/duplicate-title-2.php';
+        $this->createdFiles[] = $file1;
+        $this->createdFiles[] = $file2;
+        $this->assertFileExists($file1);
+        $this->assertFileExists($file2);
     }
 
-    public function testResetUsedSlugsClearsBatchState(): void
-    {
-        $this->service->generateSlug('Test');
-        $this->service->resetUsedSlugs();
-        $result = $this->service->generateSlug('Test');
-        $this->assertSame('test', $result);
-    }
-
-    // --- sanitizePatternContent ---
-
-    /**
-     * @dataProvider sanitizePatternContentProvider
-     */
-    public function testSanitizePatternContent(
-        string $input,
-        string $containsExpected,
-        ?string $notContainsExpected = null,
-    ): void {
-        $result = $this->service->sanitizePatternContent($input);
-        $this->assertStringContainsString($containsExpected, $result);
-        if ($notContainsExpected !== null) {
-            $this->assertStringNotContainsString($notContainsExpected, $result);
-        }
-    }
-
-    public static function sanitizePatternContentProvider(): array
-    {
-        $placeholder = 'https://cdn.sitch.co/rtc/placeholder-image.png';
-        $videoPlaceholder = 'https://cdn.sitch.co/rtc/placeholder-video.mp4';
-        return [
-            'bgImg URL replaced' => [
-                '"bgImg":"https://example.com/image.jpg"',
-                '"bgImg":"' . $placeholder . '"',
-                'example.com',
-            ],
-            'bgImgID replaced with 0' => ['"bgImgID":42', '"bgImgID":0'],
-            'video local URL replaced' => [
-                '"local":"https://example.com/video.mp4"',
-                '"local":"' . $videoPlaceholder . '"',
-                'example.com',
-            ],
-            'youtube URL cleared' => ['"youTube":"https://youtube.com/watch?v=abc"', '"youTube":""', 'youtube.com'],
-            'vimeo URL cleared' => ['"vimeo":"https://vimeo.com/123"', '"vimeo":""', 'vimeo.com'],
-            'img src replaced' => [
-                '<img src="https://example.com/photo.jpg" alt="Photo">',
-                'src="' . $placeholder . '"',
-                'example.com/photo.jpg',
-            ],
-            'alt text cleared' => [
-                '<img src="placeholder.jpg" alt="A beautiful photo">',
-                'alt=""',
-                'A beautiful photo',
-            ],
-            'http href replaced with #' => ['<a href="https://example.com/page">Link</a>', 'href="#"', 'example.com'],
-            'heading id removed' => [
-                '<h2 id="my-heading" class="wp-block-heading">Title</h2>',
-                '<h2 class="wp-block-heading">',
-                'id="my-heading"',
-            ],
-            'anchor target removed' => [
-                '<a href="#" target="_blank" rel="noopener">Link</a>',
-                '<a href="#"',
-                'target="_blank"',
-            ],
-        ];
-    }
-
-    public function testSanitizePatternContentReplacesTextWithLoremIpsum(): void
-    {
-        $input = '<p>This is some real content text</p>';
-        $result = $this->service->sanitizePatternContent($input);
-        $this->assertStringContainsString('<p>', $result);
-        $this->assertStringContainsString('</p>', $result);
-        $this->assertStringNotContainsString('This is some real content text', $result);
-        preg_match('/<p>(.+?)<\/p>/', $result, $matches);
-        $this->assertNotEmpty($matches[1]);
-        $this->assertTrue(ctype_upper($matches[1][0]));
-    }
-
-    public function testSanitizePatternContentPreservesNonHttpHrefs(): void
-    {
-        $input = '<a href="#anchor">Link</a>';
-        $result = $this->service->sanitizePatternContent($input);
-        $this->assertStringContainsString('href="#anchor"', $result);
-    }
-
-    public function testSanitizePatternContentReplacesButtonText(): void
-    {
-        $input = '<a class="wp-block-button__link" href="#">Click Here</a>';
-        $result = $this->service->sanitizePatternContent($input);
-        $this->assertStringNotContainsString('Click Here', $result);
-    }
-
-    // --- generateLoremIpsum ---
-
-    public function testGenerateLoremIpsumReturnsCorrectWordCount(): void
-    {
-        $result = $this->service->generateLoremIpsum(5);
-        $this->assertSame(5, str_word_count($result));
-    }
-
-    public function testGenerateLoremIpsumStartsWithLoremIpsum(): void
-    {
-        $result = $this->service->generateLoremIpsum(5);
-        $this->assertSame('Lorem ipsum dolor sit amet', $result);
-    }
-
-    public function testGenerateLoremIpsumReturnsEmptyForZero(): void
-    {
-        $this->assertSame('', $this->service->generateLoremIpsum(0));
-    }
-
-    public function testGenerateLoremIpsumWrapsAroundPool(): void
-    {
-        $result = $this->service->generateLoremIpsum(70);
-        $this->assertSame(70, str_word_count($result));
-    }
-
-    // --- countWords ---
-
-    /**
-     * @dataProvider countWordsProvider
-     */
-    public function testCountWords(string $input, int $expected): void
-    {
-        $this->assertSame($expected, $this->service->countWords($input));
-    }
-
-    public static function countWordsProvider(): array
-    {
-        return [
-            'plain text' => ['hello world', 2],
-            'with HTML tags' => ['<strong>hello</strong> world', 2],
-            'empty string' => ['', 0],
-            'HTML entities decoded' => ['hello&nbsp;world test', 3],
-            'only tags' => ['<br/>', 0],
-            'nested tags' => ['<p><em>one</em> <strong>two</strong></p>', 2],
-        ];
-    }
-
-    // --- formatPatternFile ---
+    // --- formatPatternFile (tested through savePatternToTheme) ---
 
     public function testFormatPatternFileGeneratesCorrectHeaders(): void
     {
@@ -211,12 +101,18 @@ class SavePatternsToThemeTest extends TestCase
             'post_content' => '<p>Hello World</p>',
         ]);
 
-        $result = $this->service->formatPatternFile($post, 'test-pattern');
-        $this->assertStringContainsString('Title: Test Pattern', $result);
-        $this->assertStringContainsString('Slug:', $result);
-        $this->assertStringContainsString('/test-pattern', $result);
-        $this->assertStringContainsString("Source Post ID: {$post->ID}", $result);
-        $this->assertStringNotContainsString('Hello World', $result);
+        $this->service->savePatternToTheme($post->ID);
+
+        $filepath = $this->patternsDir . '/test-pattern.php';
+        $this->createdFiles[] = $filepath;
+        $this->assertFileExists($filepath);
+
+        $content = file_get_contents($filepath);
+        $this->assertStringContainsString('Title: Test Pattern', $content);
+        $this->assertStringContainsString('Slug:', $content);
+        $this->assertStringContainsString('/test-pattern', $content);
+        $this->assertStringContainsString("Source Post ID: {$post->ID}", $content);
+        $this->assertStringNotContainsString('Hello World', $content);
     }
 
     public function testFormatPatternFileStripsPhpTags(): void
@@ -227,8 +123,14 @@ class SavePatternsToThemeTest extends TestCase
             'post_content' => '<?php echo "test"; ?><p>Content</p>',
         ]);
 
-        $result = $this->service->formatPatternFile($post, 'php-pattern');
-        $phpTagCount = substr_count($result, '<?php');
+        $this->service->savePatternToTheme($post->ID);
+
+        $filepath = $this->patternsDir . '/php-pattern.php';
+        $this->createdFiles[] = $filepath;
+        $this->assertFileExists($filepath);
+
+        $content = file_get_contents($filepath);
+        $phpTagCount = substr_count($content, '<?php');
         $this->assertSame(1, $phpTagCount);
     }
 
@@ -259,9 +161,15 @@ class SavePatternsToThemeTest extends TestCase
         ]);
 
         $this->service->savePatternToTheme($post->ID);
-        $this->service->resetUsedSlugs();
-        $result = $this->service->savePatternToTheme($post->ID);
-        $this->assertSame('unchanged', $result);
+
+        // Use handleRestRequest for the second save — it resets usedSlugs,
+        // simulating a separate request as happens in production.
+        $request = new WP_REST_Request('POST', '/theme/v1/save-patterns');
+        $request->set_param('pattern_ids', [$post->ID]);
+        $response = $this->service->handleRestRequest($request);
+        $data = $response->get_data();
+
+        $this->assertCount(1, $data['unchanged']);
 
         $this->createdFiles[] = $this->patternsDir . '/unchanged-test.php';
     }
@@ -275,12 +183,16 @@ class SavePatternsToThemeTest extends TestCase
         ]);
 
         $this->service->savePatternToTheme($postId);
-        $this->service->resetUsedSlugs();
 
         wp_update_post(['ID' => $postId, 'post_content' => '<p>Updated content here now</p>']);
 
-        $result = $this->service->savePatternToTheme($postId);
-        $this->assertSame('updated', $result);
+        // Use handleRestRequest for the second save — it resets usedSlugs.
+        $request = new WP_REST_Request('POST', '/theme/v1/save-patterns');
+        $request->set_param('pattern_ids', [$postId]);
+        $response = $this->service->handleRestRequest($request);
+        $data = $response->get_data();
+
+        $this->assertCount(1, $data['updated']);
 
         $this->createdFiles[] = $this->patternsDir . '/update-test.php';
     }

--- a/tests/SavePatternsToThemeTest.php
+++ b/tests/SavePatternsToThemeTest.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Parent\Modules\Patterns\SavePatternsToTheme;
+use Sitchco\Tests\TestCase;
+
+class SavePatternsToThemeTest extends TestCase
+{
+    protected SavePatternsToTheme $service;
+    private string $patternsDir;
+    private array $createdFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = $this->container->get(SavePatternsToTheme::class);
+        $this->service->resetUsedSlugs();
+        $this->patternsDir = get_stylesheet_directory() . '/patterns';
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdFiles as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+        parent::tearDown();
+    }
+
+    // --- generateSlug ---
+
+    /**
+     * @dataProvider generateSlugProvider
+     */
+    public function testGenerateSlug(string $title, string $expected): void
+    {
+        $this->assertSame($expected, $this->service->generateSlug($title));
+    }
+
+    public static function generateSlugProvider(): array
+    {
+        return [
+            'basic title' => ['My Pattern', 'my-pattern'],
+            'leading numbers stripped' => ['123 Numbered Title', 'numbered-title'],
+            'empty title falls back' => ['', 'pattern'],
+            'only numbers falls back' => ['123', 'pattern'],
+            'dashes only falls back' => ['---', 'pattern'],
+        ];
+    }
+
+    public function testGenerateSlugDeduplicatesWithinBatch(): void
+    {
+        $first = $this->service->generateSlug('Same Title');
+        $second = $this->service->generateSlug('Same Title');
+        $third = $this->service->generateSlug('Same Title');
+
+        $this->assertSame('same-title', $first);
+        $this->assertSame('same-title-2', $second);
+        $this->assertSame('same-title-3', $third);
+    }
+
+    public function testResetUsedSlugsClearsBatchState(): void
+    {
+        $this->service->generateSlug('Test');
+        $this->service->resetUsedSlugs();
+        $result = $this->service->generateSlug('Test');
+        $this->assertSame('test', $result);
+    }
+
+    // --- sanitizePatternContent ---
+
+    /**
+     * @dataProvider sanitizePatternContentProvider
+     */
+    public function testSanitizePatternContent(
+        string $input,
+        string $containsExpected,
+        ?string $notContainsExpected = null,
+    ): void {
+        $result = $this->service->sanitizePatternContent($input);
+        $this->assertStringContainsString($containsExpected, $result);
+        if ($notContainsExpected !== null) {
+            $this->assertStringNotContainsString($notContainsExpected, $result);
+        }
+    }
+
+    public static function sanitizePatternContentProvider(): array
+    {
+        $placeholder = 'https://cdn.sitch.co/rtc/placeholder-image.png';
+        $videoPlaceholder = 'https://cdn.sitch.co/rtc/placeholder-video.mp4';
+        return [
+            'bgImg URL replaced' => [
+                '"bgImg":"https://example.com/image.jpg"',
+                '"bgImg":"' . $placeholder . '"',
+                'example.com',
+            ],
+            'bgImgID replaced with 0' => ['"bgImgID":42', '"bgImgID":0'],
+            'video local URL replaced' => [
+                '"local":"https://example.com/video.mp4"',
+                '"local":"' . $videoPlaceholder . '"',
+                'example.com',
+            ],
+            'youtube URL cleared' => ['"youTube":"https://youtube.com/watch?v=abc"', '"youTube":""', 'youtube.com'],
+            'vimeo URL cleared' => ['"vimeo":"https://vimeo.com/123"', '"vimeo":""', 'vimeo.com'],
+            'img src replaced' => [
+                '<img src="https://example.com/photo.jpg" alt="Photo">',
+                'src="' . $placeholder . '"',
+                'example.com/photo.jpg',
+            ],
+            'alt text cleared' => [
+                '<img src="placeholder.jpg" alt="A beautiful photo">',
+                'alt=""',
+                'A beautiful photo',
+            ],
+            'http href replaced with #' => ['<a href="https://example.com/page">Link</a>', 'href="#"', 'example.com'],
+            'heading id removed' => [
+                '<h2 id="my-heading" class="wp-block-heading">Title</h2>',
+                '<h2 class="wp-block-heading">',
+                'id="my-heading"',
+            ],
+            'anchor target removed' => [
+                '<a href="#" target="_blank" rel="noopener">Link</a>',
+                '<a href="#"',
+                'target="_blank"',
+            ],
+        ];
+    }
+
+    public function testSanitizePatternContentReplacesTextWithLoremIpsum(): void
+    {
+        $input = '<p>This is some real content text</p>';
+        $result = $this->service->sanitizePatternContent($input);
+        $this->assertStringContainsString('<p>', $result);
+        $this->assertStringContainsString('</p>', $result);
+        $this->assertStringNotContainsString('This is some real content text', $result);
+        preg_match('/<p>(.+?)<\/p>/', $result, $matches);
+        $this->assertNotEmpty($matches[1]);
+        $this->assertTrue(ctype_upper($matches[1][0]));
+    }
+
+    public function testSanitizePatternContentPreservesNonHttpHrefs(): void
+    {
+        $input = '<a href="#anchor">Link</a>';
+        $result = $this->service->sanitizePatternContent($input);
+        $this->assertStringContainsString('href="#anchor"', $result);
+    }
+
+    public function testSanitizePatternContentReplacesButtonText(): void
+    {
+        $input = '<a class="wp-block-button__link" href="#">Click Here</a>';
+        $result = $this->service->sanitizePatternContent($input);
+        $this->assertStringNotContainsString('Click Here', $result);
+    }
+
+    // --- generateLoremIpsum ---
+
+    public function testGenerateLoremIpsumReturnsCorrectWordCount(): void
+    {
+        $result = $this->service->generateLoremIpsum(5);
+        $this->assertSame(5, str_word_count($result));
+    }
+
+    public function testGenerateLoremIpsumStartsWithLoremIpsum(): void
+    {
+        $result = $this->service->generateLoremIpsum(5);
+        $this->assertSame('Lorem ipsum dolor sit amet', $result);
+    }
+
+    public function testGenerateLoremIpsumReturnsEmptyForZero(): void
+    {
+        $this->assertSame('', $this->service->generateLoremIpsum(0));
+    }
+
+    public function testGenerateLoremIpsumWrapsAroundPool(): void
+    {
+        $result = $this->service->generateLoremIpsum(70);
+        $this->assertSame(70, str_word_count($result));
+    }
+
+    // --- countWords ---
+
+    /**
+     * @dataProvider countWordsProvider
+     */
+    public function testCountWords(string $input, int $expected): void
+    {
+        $this->assertSame($expected, $this->service->countWords($input));
+    }
+
+    public static function countWordsProvider(): array
+    {
+        return [
+            'plain text' => ['hello world', 2],
+            'with HTML tags' => ['<strong>hello</strong> world', 2],
+            'empty string' => ['', 0],
+            'HTML entities decoded' => ['hello&nbsp;world test', 3],
+            'only tags' => ['<br/>', 0],
+            'nested tags' => ['<p><em>one</em> <strong>two</strong></p>', 2],
+        ];
+    }
+
+    // --- formatPatternFile ---
+
+    public function testFormatPatternFileGeneratesCorrectHeaders(): void
+    {
+        $post = $this->factory()->post->create_and_get([
+            'post_type' => 'wp_block',
+            'post_title' => 'Test Pattern',
+            'post_content' => '<p>Hello World</p>',
+        ]);
+
+        $result = $this->service->formatPatternFile($post, 'test-pattern');
+        $this->assertStringContainsString('Title: Test Pattern', $result);
+        $this->assertStringContainsString('Slug:', $result);
+        $this->assertStringContainsString('/test-pattern', $result);
+        $this->assertStringContainsString("Source Post ID: {$post->ID}", $result);
+        $this->assertStringNotContainsString('Hello World', $result);
+    }
+
+    public function testFormatPatternFileStripsPhpTags(): void
+    {
+        $post = $this->factory()->post->create_and_get([
+            'post_type' => 'wp_block',
+            'post_title' => 'PHP Pattern',
+            'post_content' => '<?php echo "test"; ?><p>Content</p>',
+        ]);
+
+        $result = $this->service->formatPatternFile($post, 'php-pattern');
+        $phpTagCount = substr_count($result, '<?php');
+        $this->assertSame(1, $phpTagCount);
+    }
+
+    // --- savePatternToTheme ---
+
+    public function testSavePatternToThemeCreatesFile(): void
+    {
+        $post = $this->factory()->post->create_and_get([
+            'post_type' => 'wp_block',
+            'post_title' => 'Save Test Pattern',
+            'post_content' => '<p>Some content</p>',
+        ]);
+
+        $result = $this->service->savePatternToTheme($post->ID);
+        $this->assertSame('created', $result);
+
+        $filepath = $this->patternsDir . '/save-test-pattern.php';
+        $this->createdFiles[] = $filepath;
+        $this->assertFileExists($filepath);
+    }
+
+    public function testSavePatternToThemeReturnsUnchangedOnSecondCall(): void
+    {
+        $post = $this->factory()->post->create_and_get([
+            'post_type' => 'wp_block',
+            'post_title' => 'Unchanged Test',
+            'post_content' => '<p>Same content</p>',
+        ]);
+
+        $this->service->savePatternToTheme($post->ID);
+        $this->service->resetUsedSlugs();
+        $result = $this->service->savePatternToTheme($post->ID);
+        $this->assertSame('unchanged', $result);
+
+        $this->createdFiles[] = $this->patternsDir . '/unchanged-test.php';
+    }
+
+    public function testSavePatternToThemeReturnsUpdatedOnContentChange(): void
+    {
+        $postId = $this->factory()->post->create([
+            'post_type' => 'wp_block',
+            'post_title' => 'Update Test',
+            'post_content' => '<p>Original</p>',
+        ]);
+
+        $this->service->savePatternToTheme($postId);
+        $this->service->resetUsedSlugs();
+
+        wp_update_post(['ID' => $postId, 'post_content' => '<p>Updated content here now</p>']);
+
+        $result = $this->service->savePatternToTheme($postId);
+        $this->assertSame('updated', $result);
+
+        $this->createdFiles[] = $this->patternsDir . '/update-test.php';
+    }
+
+    public function testSavePatternToThemeRejectsInvalidPost(): void
+    {
+        $result = $this->service->savePatternToTheme(999999);
+        $this->assertSame('Invalid pattern post', $result);
+    }
+
+    public function testSavePatternToThemeRejectsNonWpBlockPost(): void
+    {
+        $postId = $this->factory()->post->create(['post_type' => 'post']);
+        $result = $this->service->savePatternToTheme($postId);
+        $this->assertSame('Invalid pattern post', $result);
+    }
+}

--- a/tests/SiteFooterModuleTest.php
+++ b/tests/SiteFooterModuleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Parent\Modules\ContentPartial\ContentPartialService;
+use Sitchco\Parent\Modules\SiteFooter\SiteFooterModule;
+use Sitchco\Tests\TestCase;
+
+class SiteFooterModuleTest extends TestCase
+{
+    protected SiteFooterModule $module;
+    protected ContentPartialService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = $this->container->get(SiteFooterModule::class);
+        $this->service = $this->container->get(ContentPartialService::class);
+    }
+
+    public function testInitAddsFooterTemplateAreaWithContext(): void
+    {
+        $areas = $this->service->getTemplateAreas();
+        $this->assertArrayHasKey('footer', $areas);
+        $this->assertTrue($areas['footer']);
+    }
+}

--- a/tests/SiteHeaderModuleTest.php
+++ b/tests/SiteHeaderModuleTest.php
@@ -46,4 +46,18 @@ class SiteHeaderModuleTest extends TestCase
         $result = $this->module->addPageContextToSiteHeader($context);
         $this->assertFalse($result['site_header']->is_overlaid);
     }
+
+    public function testAddPageContextSetsOverlaidTrueWhenSingularWithOverlay(): void
+    {
+        $pageId = $this->factory()->post->create(['post_type' => 'page']);
+        $this->go_to(get_permalink($pageId));
+        $this->assertTrue(is_singular(), 'Expected singular context');
+
+        update_field('header_overlay', true, $pageId);
+
+        $header = new \stdClass();
+        $context = ['site_header' => $header];
+        $result = $this->module->addPageContextToSiteHeader($context);
+        $this->assertTrue($result['site_header']->is_overlaid);
+    }
 }

--- a/tests/SiteHeaderModuleTest.php
+++ b/tests/SiteHeaderModuleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Parent\Modules\ContentPartial\ContentPartialService;
+use Sitchco\Parent\Modules\SiteHeader\SiteHeaderModule;
+use Sitchco\Tests\TestCase;
+use Sitchco\Utils\Hooks;
+
+class SiteHeaderModuleTest extends TestCase
+{
+    protected SiteHeaderModule $module;
+    protected ContentPartialService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = $this->container->get(SiteHeaderModule::class);
+        $this->service = $this->container->get(ContentPartialService::class);
+    }
+
+    public function testInitAddsHeaderTemplateAreaWithContext(): void
+    {
+        $areas = $this->service->getTemplateAreas();
+        $this->assertArrayHasKey('header', $areas);
+        $this->assertTrue($areas['header']);
+    }
+
+    public function testInitRegistersTemplateContextFilter(): void
+    {
+        $hookName = Hooks::name('template-context/partials/site-header');
+        $this->assertGreaterThan(0, has_filter($hookName, [$this->module, 'addPageContextToSiteHeader']));
+    }
+
+    public function testAddPageContextReturnsEarlyWithoutSiteHeader(): void
+    {
+        $context = ['other_key' => 'value'];
+        $result = $this->module->addPageContextToSiteHeader($context);
+        $this->assertSame($context, $result);
+    }
+
+    public function testAddPageContextSetsOverlaidFalseByDefault(): void
+    {
+        $header = new \stdClass();
+        $context = ['site_header' => $header];
+        $result = $this->module->addPageContextToSiteHeader($context);
+        $this->assertFalse($result['site_header']->is_overlaid);
+    }
+}

--- a/tests/ThemeModuleTest.php
+++ b/tests/ThemeModuleTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Sitchco\Parent\Tests;
+
+use Sitchco\Modules\UIModal\ModalData;
+use Sitchco\Parent\Modules\Theme\Theme;
+use Sitchco\Tests\TestCase;
+
+class ThemeModuleTest extends TestCase
+{
+    protected Theme $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = $this->container->get(Theme::class);
+    }
+
+    // --- addButtonThemeAttribute ---
+
+    public function testAddButtonThemeAttributeAddsThemeToButton(): void
+    {
+        $args = ['attributes' => []];
+        $result = $this->module->addButtonThemeAttribute($args, 'core/button');
+        $this->assertArrayHasKey('theme', $result['attributes']);
+        $this->assertSame('string', $result['attributes']['theme']['type']);
+        $this->assertSame('', $result['attributes']['theme']['default']);
+    }
+
+    public function testAddButtonThemeAttributeIgnoresOtherBlocks(): void
+    {
+        $args = ['attributes' => ['existing' => true]];
+        $result = $this->module->addButtonThemeAttribute($args, 'core/paragraph');
+        $this->assertArrayNotHasKey('theme', $result['attributes']);
+        $this->assertSame(['existing' => true], $result['attributes']);
+    }
+
+    public function testAddButtonThemeAttributePreservesExistingAttributes(): void
+    {
+        $args = ['attributes' => ['className' => ['type' => 'string']]];
+        $result = $this->module->addButtonThemeAttribute($args, 'core/button');
+        $this->assertArrayHasKey('className', $result['attributes']);
+        $this->assertArrayHasKey('theme', $result['attributes']);
+    }
+
+    // --- contentFilterWarning ---
+
+    public function testContentFilterWarningReturnsContentUnchanged(): void
+    {
+        // Simulate normal conditions: wp_head has fired
+        do_action('wp_head');
+        $content = '<p>Hello world</p>';
+        $result = $this->module->contentFilterWarning($content);
+        $this->assertSame($content, $result);
+    }
+
+    public function testContentFilterWarningReturnsContentInAdmin(): void
+    {
+        // is_admin() returns true during test suite since we're in WP test context
+        // but did_action('wp_head') is typically > 0 after setUp, so we test
+        // the method always returns the content string regardless of warning state
+        $content = '<p>Admin content</p>';
+        $result = $this->module->contentFilterWarning($content);
+        $this->assertSame($content, $result);
+    }
+
+    public function testContentFilterWarningAlwaysReturnsOriginalContent(): void
+    {
+        $content = '<p>Some content with <strong>HTML</strong></p>';
+        $result = $this->module->contentFilterWarning($content);
+        $this->assertSame($content, $result);
+    }
+
+    // --- modalContentAttributes ---
+
+    public function testModalContentAttributesSkipsVideoType(): void
+    {
+        $modalData = new ModalData('test-video', 'Video Modal', '<p>video</p>', 'video');
+        $attrs = ['class' => ['existing-class']];
+        $result = $this->module->modalContentAttributes($attrs, $modalData);
+        $this->assertSame($attrs, $result);
+    }
+
+    public function testModalContentAttributesAddsLayoutClasses(): void
+    {
+        $modalData = new ModalData('test-modal', 'Test Modal', '<p>content</p>', 'full');
+        $attrs = ['class' => ['existing-class']];
+        $result = $this->module->modalContentAttributes($attrs, $modalData);
+        $this->assertContains('existing-class', $result['class']);
+        $this->assertContains('is-layout-constrained', $result['class']);
+        $this->assertContains('has-global-padding', $result['class']);
+    }
+
+    public function testModalContentAttributesHandlesMissingClassKey(): void
+    {
+        $modalData = new ModalData('test-modal', 'Test Modal', '<p>content</p>', 'full');
+        $attrs = [];
+        $result = $this->module->modalContentAttributes($attrs, $modalData);
+        $this->assertContains('is-layout-constrained', $result['class']);
+        $this->assertContains('has-global-padding', $result['class']);
+    }
+
+    public function testModalContentAttributesHandlesStringClass(): void
+    {
+        $modalData = new ModalData('test-modal', 'Test Modal', '<p>content</p>', 'full');
+        $attrs = ['class' => 'single-class'];
+        $result = $this->module->modalContentAttributes($attrs, $modalData);
+        $this->assertContains('single-class', $result['class']);
+        $this->assertContains('is-layout-constrained', $result['class']);
+    }
+
+    public function testModalContentAttributesPreservesOtherAttrs(): void
+    {
+        $modalData = new ModalData('test-modal', 'Test Modal', '<p>content</p>', 'content');
+        $attrs = ['id' => 'custom-id', 'class' => []];
+        $result = $this->module->modalContentAttributes($attrs, $modalData);
+        $this->assertSame('custom-id', $result['id']);
+    }
+
+    public static function nonVideoTypeProvider(): array
+    {
+        return [
+            'full' => ['full'],
+            'content' => ['content'],
+            'image' => ['image'],
+            'custom' => ['custom-type'],
+        ];
+    }
+
+    /**
+     * @dataProvider nonVideoTypeProvider
+     */
+    public function testModalContentAttributesAddsClassesForNonVideoTypes(string $type): void
+    {
+        $modalData = new ModalData('test-modal', 'Test Modal', '<p>content</p>', $type);
+        $result = $this->module->modalContentAttributes([], $modalData);
+        $this->assertContains('is-layout-constrained', $result['class']);
+        $this->assertContains('has-global-padding', $result['class']);
+    }
+}

--- a/tests/ThemeModuleTest.php
+++ b/tests/ThemeModuleTest.php
@@ -45,30 +45,27 @@ class ThemeModuleTest extends TestCase
 
     // --- contentFilterWarning ---
 
-    public function testContentFilterWarningReturnsContentUnchanged(): void
+    public function testContentFilterWarningReturnsContentWhenHeadFired(): void
     {
-        // Simulate normal conditions: wp_head has fired
         do_action('wp_head');
         $content = '<p>Hello world</p>';
         $result = $this->module->contentFilterWarning($content);
         $this->assertSame($content, $result);
     }
 
-    public function testContentFilterWarningReturnsContentInAdmin(): void
+    public function testContentFilterWarningLogsAndInjectsActionWhenCalledTooEarly(): void
     {
-        // is_admin() returns true during test suite since we're in WP test context
-        // but did_action('wp_head') is typically > 0 after setUp, so we test
-        // the method always returns the content string regardless of warning state
-        $content = '<p>Admin content</p>';
-        $result = $this->module->contentFilterWarning($content);
-        $this->assertSame($content, $result);
-    }
+        // Ensure none of the bypass conditions are met
+        remove_all_actions('wp_body_open');
+        $this->assertFalse(has_action('wp_body_open'), 'Precondition: no wp_body_open actions');
+        $GLOBALS['wp_actions']['wp_head'] = 0;
+        set_current_screen('front');
 
-    public function testContentFilterWarningAlwaysReturnsOriginalContent(): void
-    {
-        $content = '<p>Some content with <strong>HTML</strong></p>';
+        $content = '<p>Early content</p>';
         $result = $this->module->contentFilterWarning($content);
-        $this->assertSame($content, $result);
+
+        $this->assertSame($content, $result, 'Content should still be returned unchanged');
+        $this->assertNotFalse(has_action('wp_body_open'), 'Expected wp_body_open action to be registered');
     }
 
     // --- modalContentAttributes ---


### PR DESCRIPTION
## Summary
- Add tests for **Theme** module: `addButtonThemeAttribute`, `contentFilterWarning`, `modalContentAttributes`
- Add tests for **SiteHeader** module: template area registration, filter registration, `addPageContextToSiteHeader` guard clause and default state
- Add tests for **SiteFooter** module: template area registration
- Tests for ExtendBlock, GravityForms, KadenceBlocks, Patterns, ButtonConfig, CloudinaryKadence, ContentPartialBlock, ContentSlider, and ContentPartial modules (from prior commits on this branch)
- Minor visibility adjustments to support testability

## Test plan
- [x] All new tests pass via `ddev test-phpunit`
- [ ] Verify no regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)